### PR TITLE
fix(a2a-pb): ignore unknown fields in ProtoJSON decode (spec §5.7)

### DIFF
--- a/a2a-pb/build.rs
+++ b/a2a-pb/build.rs
@@ -120,6 +120,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = pbjson_build::Builder::new();
     builder.out_dir(&out_dir);
     builder.register_descriptors(&descriptor_set)?;
+    // Spec §5.7: implementations SHOULD ignore unrecognized fields in
+    // messages, allowing for forward compatibility. Unknown enum string
+    // values are still rejected.
+    builder.ignore_unknown_fields();
     builder.build(PROTOJSON_PACKAGES)?;
     patch_generated_protojson_serde(&out_dir)?;
 

--- a/a2a-pb/tests/protojson.rs
+++ b/a2a-pb/tests/protojson.rs
@@ -227,6 +227,46 @@ fn agent_card_protojson_deserializes_null_skills_as_empty() {
     assert_eq!(parsed, expected);
 }
 
+/// Spec §5.7: implementations SHOULD ignore unrecognized fields in messages,
+/// allowing for forward compatibility. Unknown fields must be tolerated both
+/// at the top level and inside nested messages.
+#[test]
+fn task_protojson_decode_ignores_unknown_fields() {
+    let json = json!({
+        "id": "task-1",
+        "contextId": "ctx-1",
+        "status": {
+            "state": "TASK_STATE_COMPLETED",
+            "futureStatusField": "ignored"
+        },
+        "futureTopLevelField": {"nested": ["values", 1, true]}
+    });
+
+    let task = a2a_pb::protojson_conv::from_value::<a2a::Task>(json)
+        .expect("unknown fields must be ignored");
+    assert_eq!(task.id, "task-1");
+    assert_eq!(task.context_id, "ctx-1");
+    assert_eq!(task.status.state, a2a::TaskState::Completed);
+}
+
+/// Unknown *enum string values* are still rejected: only unrecognized fields
+/// are tolerated (`ignore_unknown_enum_variants` is intentionally not
+/// enabled).
+#[test]
+fn task_protojson_decode_rejects_unknown_enum_values() {
+    let json = json!({
+        "id": "task-1",
+        "contextId": "ctx-1",
+        "status": {"state": "TASK_STATE_FROM_THE_FUTURE"}
+    });
+
+    let result = a2a_pb::protojson_conv::from_value::<a2a::Task>(json);
+    assert!(
+        result.is_err(),
+        "unknown enum values must still be rejected"
+    );
+}
+
 #[test]
 fn stream_response_protojson_roundtrip_serializes_oneof_payloads() {
     let response = StreamResponse {

--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -410,10 +410,35 @@ mod tests {
     #[tokio::test]
     async fn test_invalid_params() {
         let app = make_app();
-        let params = serde_json::json!({"bogus": true});
+        // Type mismatch: `message` must be an object. A merely-unknown field
+        // is not invalid params; it is ignored per spec §5.7.
+        let params = serde_json::json!({"message": "not-an-object"});
         let resp = post_jsonrpc(app, methods::SEND_MESSAGE, params).await;
         assert!(resp.error.is_some());
         assert_eq!(resp.error.unwrap().code, error_code::PARSE_ERROR);
+    }
+
+    /// Spec §5.7: unrecognized fields in request params are ignored for
+    /// forward compatibility instead of being rejected.
+    #[tokio::test]
+    async fn test_unknown_params_fields_are_ignored() {
+        let app = make_app();
+        let params = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hi"}],
+                "futureField": true
+            },
+            "anotherFutureField": {"nested": 1}
+        });
+        let resp = post_jsonrpc(app, methods::SEND_MESSAGE, params).await;
+        assert!(
+            resp.error.is_none(),
+            "unknown fields must be ignored: {:?}",
+            resp.error
+        );
+        assert!(resp.result.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Spec §5.7: "Implementations SHOULD ignore unrecognized fields in messages, allowing for forward compatibility as the protocol evolves." The pbjson-generated deserializers reject unknown fields, so any peer that sends a forward-compatible extra field (or a newer protocol revision) fails to decode.

## Fix

One line in `a2a-pb/build.rs`: `.ignore_unknown_fields()` on the `pbjson_build::Builder` (supported by the pbjson-build 0.9.0 already in the workspace). Unknown fields now route to the generated `__SkipField__` arm. All existing post-generation replacements (`NULL_REPEATED_FIELD_REPLACEMENTS`, map handling) still match — the generated serde code lives in `OUT_DIR`, so no committed generated files change.

`ignore_unknown_enum_variants` is deliberately **not** enabled: unknown enum *string values* still error, preserving strictness where the spec doesn't ask for leniency.

## Heads-up for review: one existing test fixture changed

`a2a-server`'s `test_invalid_params` used `{"bogus": true}` — a merely-unknown field — as its invalid-params fixture. Under §5.7 semantics that payload is now *valid* (decodes to a default request). The test now uses a genuine type mismatch (`{"message": "not-an-object"}`) with the same error-code assertion, and a new `test_unknown_params_fields_are_ignored` pins the tolerance end-to-end through the JSON-RPC server.

## Found by / verified with

Cross-SDK interop testing ([a2a-conformance](https://github.com/arkavo-ai/a2a-conformance), scenario `edge/unknown-field-tolerance`; [FINDINGS.md](https://github.com/arkavo-ai/a2a-conformance/blob/main/FINDINGS.md) finding 2). New round-trip tests in `a2a-pb/tests/` (unknown top-level + nested fields accepted; unknown enum values still rejected); `cargo test --workspace` 450 passed / 0 failed (baseline 447/0); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)