### PR TITLE
feat(cli): redesign a2a CLI — transport flag, .a2a.yaml config, tenant injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,8 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.2.3"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 pbjson = "0.9"
 pbjson-types = "0.9"
 

--- a/README.md
+++ b/README.md
@@ -142,18 +142,30 @@ HTTP+JSON, prints responses as JSON, and manages task push notification
 configs.
 
 ```sh
-cargo run --bin a2acli -- card
-cargo run --bin a2acli -- send "hello from rust"
-cargo run --bin a2acli -- stream "hello from rust"
-cargo run --bin a2acli -- list-tasks
-cargo run --bin a2acli -- push-config list task-123
+# Inspect an agent card
+a2a discover http://localhost:3000
+
+# Send a one-shot message
+a2a send http://localhost:3000 "hello from rust"
+
+# Send a streaming message
+a2a stream http://localhost:3000 "hello from rust"
+
+# List tasks
+a2a task list http://localhost:3000
+
+# Manage push notification configs
+a2a push-config list http://localhost:3000 task-123
 ```
 
-By default the CLI targets `http://localhost:3000`, which matches the bundled
-hello world server. Override the target with `--base-url https://host` for any
-compatible A2A server, use `--binding jsonrpc` or `--binding http-json` to pin
+Each command takes an agent reference as its first argument: a base URL
+(`http://host` → card fetched from `/.well-known/agent-card.json`), a direct
+URL to a card JSON file (`https://host/path/agent.json`), or a local file path.
+Use `--enabled-binding jsonrpc` or `--enabled-binding http-json` to pin
 transport selection, and pass `--bearer-token` or repeated `--header Name:Value`
 arguments when the server requires authentication.
+
+See [`a2acli/README.md`](a2acli/README.md) for the full command reference.
 
 ## Depending On The Workspace
 

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -14,6 +14,7 @@ pub struct A2AClient<T: Transport> {
     transport: T,
     interceptors: Vec<Arc<dyn CallInterceptor>>,
     default_params: ServiceParams,
+    tenant: Option<String>,
 }
 
 impl<T: Transport> A2AClient<T> {
@@ -24,11 +25,17 @@ impl<T: Transport> A2AClient<T> {
             transport,
             interceptors: Vec::new(),
             default_params,
+            tenant: None,
         }
     }
 
     pub fn with_interceptors(mut self, interceptors: Vec<Arc<dyn CallInterceptor>>) -> Self {
         self.interceptors = interceptors;
+        self
+    }
+
+    pub fn with_tenant(mut self, tenant: Option<String>) -> Self {
+        self.tenant = tenant;
         self
     }
 
@@ -75,7 +82,11 @@ impl<T: Transport> A2AClient<T> {
         req: &SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
         let params = self.apply_before(methods::SEND_MESSAGE).await?;
-        let result = self.transport.send_message(&params, req).await;
+        let patched = SendMessageRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.send_message(&params, &patched).await;
         self.finish_call(methods::SEND_MESSAGE, result).await
     }
 
@@ -84,26 +95,45 @@ impl<T: Transport> A2AClient<T> {
         req: &SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SEND_STREAMING_MESSAGE).await?;
-        let result = self.transport.send_streaming_message(&params, req).await;
+        let patched = SendMessageRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self
+            .transport
+            .send_streaming_message(&params, &patched)
+            .await;
         self.finish_call(methods::SEND_STREAMING_MESSAGE, result)
             .await
     }
 
     pub async fn get_task(&self, req: &GetTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::GET_TASK).await?;
-        let result = self.transport.get_task(&params, req).await;
+        let patched = GetTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.get_task(&params, &patched).await;
         self.finish_call(methods::GET_TASK, result).await
     }
 
     pub async fn list_tasks(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
         let params = self.apply_before(methods::LIST_TASKS).await?;
-        let result = self.transport.list_tasks(&params, req).await;
+        let patched = ListTasksRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.list_tasks(&params, &patched).await;
         self.finish_call(methods::LIST_TASKS, result).await
     }
 
     pub async fn cancel_task(&self, req: &CancelTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::CANCEL_TASK).await?;
-        let result = self.transport.cancel_task(&params, req).await;
+        let patched = CancelTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.cancel_task(&params, &patched).await;
         self.finish_call(methods::CANCEL_TASK, result).await
     }
 
@@ -112,7 +142,11 @@ impl<T: Transport> A2AClient<T> {
         req: &SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SUBSCRIBE_TO_TASK).await?;
-        let result = self.transport.subscribe_to_task(&params, req).await;
+        let patched = SubscribeToTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.subscribe_to_task(&params, &patched).await;
         self.finish_call(methods::SUBSCRIBE_TO_TASK, result).await
     }
 
@@ -121,7 +155,11 @@ impl<T: Transport> A2AClient<T> {
         req: &TaskPushNotificationConfig,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::CREATE_PUSH_CONFIG).await?;
-        let result = self.transport.create_push_config(&params, req).await;
+        let patched = TaskPushNotificationConfig {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.create_push_config(&params, &patched).await;
         self.finish_call(methods::CREATE_PUSH_CONFIG, result).await
     }
 
@@ -130,7 +168,11 @@ impl<T: Transport> A2AClient<T> {
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::GET_PUSH_CONFIG).await?;
-        let result = self.transport.get_push_config(&params, req).await;
+        let patched = GetTaskPushNotificationConfigRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.get_push_config(&params, &patched).await;
         self.finish_call(methods::GET_PUSH_CONFIG, result).await
     }
 
@@ -139,7 +181,11 @@ impl<T: Transport> A2AClient<T> {
         req: &ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
         let params = self.apply_before(methods::LIST_PUSH_CONFIGS).await?;
-        let result = self.transport.list_push_configs(&params, req).await;
+        let patched = ListTaskPushNotificationConfigsRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.list_push_configs(&params, &patched).await;
         self.finish_call(methods::LIST_PUSH_CONFIGS, result).await
     }
 
@@ -148,7 +194,11 @@ impl<T: Transport> A2AClient<T> {
         req: &DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         let params = self.apply_before(methods::DELETE_PUSH_CONFIG).await?;
-        let result = self.transport.delete_push_config(&params, req).await;
+        let patched = DeleteTaskPushNotificationConfigRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.delete_push_config(&params, &patched).await;
         self.finish_call(methods::DELETE_PUSH_CONFIG, result).await
     }
 
@@ -157,7 +207,14 @@ impl<T: Transport> A2AClient<T> {
         req: &GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
         let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
-        let result = self.transport.get_extended_agent_card(&params, req).await;
+        let patched = GetExtendedAgentCardRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self
+            .transport
+            .get_extended_agent_card(&params, &patched)
+            .await;
         self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
             .await
     }

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -79,141 +79,108 @@ impl<T: Transport> A2AClient<T> {
 
     pub async fn send_message(
         &self,
-        req: &SendMessageRequest,
+        mut req: SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
         let params = self.apply_before(methods::SEND_MESSAGE).await?;
-        let patched = SendMessageRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.send_message(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.send_message(&params, &req).await;
         self.finish_call(methods::SEND_MESSAGE, result).await
     }
 
     pub async fn send_streaming_message(
         &self,
-        req: &SendMessageRequest,
+        mut req: SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SEND_STREAMING_MESSAGE).await?;
-        let patched = SendMessageRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self
-            .transport
-            .send_streaming_message(&params, &patched)
-            .await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.send_streaming_message(&params, &req).await;
         self.finish_call(methods::SEND_STREAMING_MESSAGE, result)
             .await
     }
 
-    pub async fn get_task(&self, req: &GetTaskRequest) -> Result<Task, A2AError> {
+    pub async fn get_task(&self, mut req: GetTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::GET_TASK).await?;
-        let patched = GetTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.get_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.get_task(&params, &req).await;
         self.finish_call(methods::GET_TASK, result).await
     }
 
-    pub async fn list_tasks(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
+    pub async fn list_tasks(
+        &self,
+        mut req: ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
         let params = self.apply_before(methods::LIST_TASKS).await?;
-        let patched = ListTasksRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.list_tasks(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.list_tasks(&params, &req).await;
         self.finish_call(methods::LIST_TASKS, result).await
     }
 
-    pub async fn cancel_task(&self, req: &CancelTaskRequest) -> Result<Task, A2AError> {
+    pub async fn cancel_task(&self, mut req: CancelTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::CANCEL_TASK).await?;
-        let patched = CancelTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.cancel_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.cancel_task(&params, &req).await;
         self.finish_call(methods::CANCEL_TASK, result).await
     }
 
     pub async fn subscribe_to_task(
         &self,
-        req: &SubscribeToTaskRequest,
+        mut req: SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SUBSCRIBE_TO_TASK).await?;
-        let patched = SubscribeToTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.subscribe_to_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.subscribe_to_task(&params, &req).await;
         self.finish_call(methods::SUBSCRIBE_TO_TASK, result).await
     }
 
     pub async fn create_push_config(
         &self,
-        req: &TaskPushNotificationConfig,
+        mut req: TaskPushNotificationConfig,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::CREATE_PUSH_CONFIG).await?;
-        let patched = TaskPushNotificationConfig {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.create_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.create_push_config(&params, &req).await;
         self.finish_call(methods::CREATE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_push_config(
         &self,
-        req: &GetTaskPushNotificationConfigRequest,
+        mut req: GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::GET_PUSH_CONFIG).await?;
-        let patched = GetTaskPushNotificationConfigRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.get_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.get_push_config(&params, &req).await;
         self.finish_call(methods::GET_PUSH_CONFIG, result).await
     }
 
     pub async fn list_push_configs(
         &self,
-        req: &ListTaskPushNotificationConfigsRequest,
+        mut req: ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
         let params = self.apply_before(methods::LIST_PUSH_CONFIGS).await?;
-        let patched = ListTaskPushNotificationConfigsRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.list_push_configs(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.list_push_configs(&params, &req).await;
         self.finish_call(methods::LIST_PUSH_CONFIGS, result).await
     }
 
     pub async fn delete_push_config(
         &self,
-        req: &DeleteTaskPushNotificationConfigRequest,
+        mut req: DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         let params = self.apply_before(methods::DELETE_PUSH_CONFIG).await?;
-        let patched = DeleteTaskPushNotificationConfigRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.delete_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.delete_push_config(&params, &req).await;
         self.finish_call(methods::DELETE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_extended_agent_card(
         &self,
-        req: &GetExtendedAgentCardRequest,
+        mut req: GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
         let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
-        let patched = GetExtendedAgentCardRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
+        req.tenant = self.tenant.clone();
         let result = self
             .transport
-            .get_extended_agent_card(&params, &patched)
+            .get_extended_agent_card(&params, &req)
             .await;
         self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
             .await
@@ -246,7 +213,7 @@ impl<T: Transport> SendMessageExt for A2AClient<T> {
             metadata: None,
             tenant: None,
         };
-        self.send_message(&req).await
+        self.send_message(req).await
     }
 }
 
@@ -533,7 +500,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let resp = client.send_message(&req).await.unwrap();
+        let resp = client.send_message(req).await.unwrap();
         assert!(matches!(resp, SendMessageResponse::Task(_)));
     }
 
@@ -559,7 +526,7 @@ mod tests {
             tenant: None,
         };
 
-        client.send_message(&req).await.unwrap();
+        client.send_message(req).await.unwrap();
 
         let calls = state.calls.lock().unwrap();
         let params = &calls[0].1;
@@ -598,7 +565,7 @@ mod tests {
             tenant: None,
         };
 
-        let err = client.send_message(&req).await.unwrap_err();
+        let err = client.send_message(req).await.unwrap_err();
         assert_eq!(err.message, "boom");
 
         let events = events.lock().unwrap().clone();
@@ -618,7 +585,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let mut stream = client.send_streaming_message(&req).await.unwrap();
+        let mut stream = client.send_streaming_message(req).await.unwrap();
         let item = stream.next().await.unwrap().unwrap();
         assert!(matches!(item, StreamResponse::StatusUpdate(_)));
     }
@@ -631,7 +598,7 @@ mod tests {
             history_length: None,
             tenant: None,
         };
-        let task = client.get_task(&req).await.unwrap();
+        let task = client.get_task(req).await.unwrap();
         assert_eq!(task.id, "t1");
     }
 
@@ -648,7 +615,7 @@ mod tests {
             include_artifacts: None,
             tenant: None,
         };
-        let resp = client.list_tasks(&req).await.unwrap();
+        let resp = client.list_tasks(req).await.unwrap();
         assert!(resp.tasks.is_empty());
     }
 
@@ -660,7 +627,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let task = client.cancel_task(&req).await.unwrap();
+        let task = client.cancel_task(req).await.unwrap();
         assert_eq!(task.status.state, TaskState::Canceled);
     }
 
@@ -671,7 +638,7 @@ mod tests {
             id: "t1".into(),
             tenant: None,
         };
-        let _stream = client.subscribe_to_task(&req).await.unwrap();
+        let _stream = client.subscribe_to_task(req).await.unwrap();
     }
 
     #[tokio::test]
@@ -685,7 +652,7 @@ mod tests {
             authentication: None,
             tenant: None,
         };
-        let resp = client.create_push_config(&req).await.unwrap();
+        let resp = client.create_push_config(req).await.unwrap();
         assert_eq!(resp.task_id, "t1");
     }
 
@@ -697,7 +664,7 @@ mod tests {
             id: "cfg1".into(),
             tenant: None,
         };
-        let resp = client.get_push_config(&req).await.unwrap();
+        let resp = client.get_push_config(req).await.unwrap();
         assert_eq!(resp.id, Some("cfg1".into()));
     }
 
@@ -710,7 +677,7 @@ mod tests {
             page_token: None,
             tenant: None,
         };
-        let resp = client.list_push_configs(&req).await.unwrap();
+        let resp = client.list_push_configs(req).await.unwrap();
         assert!(resp.configs.is_empty());
     }
 
@@ -722,14 +689,14 @@ mod tests {
             id: "cfg1".into(),
             tenant: None,
         };
-        client.delete_push_config(&req).await.unwrap();
+        client.delete_push_config(req).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_extended_agent_card() {
         let client = make_client();
         let req = GetExtendedAgentCardRequest { tenant: None };
-        let card = client.get_extended_agent_card(&req).await.unwrap();
+        let card = client.get_extended_agent_card(req).await.unwrap();
         assert_eq!(card.name, "Test");
     }
 

--- a/a2a-client/src/factory.rs
+++ b/a2a-client/src/factory.rs
@@ -100,9 +100,9 @@ impl A2AClientFactory {
         for (_prio, iface, factory) in &candidates {
             match factory.create(card, iface).await {
                 Ok(transport) => {
-                    return Ok(
-                        A2AClient::new(transport).with_interceptors(self.interceptors.clone())
-                    );
+                    return Ok(A2AClient::new(transport)
+                        .with_tenant(iface.tenant.clone())
+                        .with_interceptors(self.interceptors.clone()));
                 }
                 Err(e) => {
                     tracing::debug!(

--- a/a2acli-skill/SKILL.md
+++ b/a2acli-skill/SKILL.md
@@ -1,0 +1,127 @@
+# a2acli skill
+
+Use this skill to interact with A2A-compatible agents from the command line using the `a2a` binary.
+
+## When to use
+
+- Inspect an agent's capabilities by fetching its agent card
+- Send one-shot or streaming messages to an A2A agent
+- Retrieve, list, cancel, or subscribe to tasks on an agent
+- Manage push notification configs for tasks
+- Diagnose A2A agent deployments or script A2A workflows in a shell
+
+## Install
+
+```sh
+# macOS
+brew tap a2aproject/a2a-rs https://github.com/a2aproject/a2a-rs
+brew trust a2aproject/a2a-rs
+brew install a2acli
+
+# Linux
+curl -fsSL https://raw.githubusercontent.com/a2aproject/a2a-rs/main/install.sh | bash
+
+# From source
+cargo install a2a-cli
+```
+
+## Usage patterns
+
+### Agent reference (`AGENT_REF`)
+
+Every command takes an `AGENT_REF` as its first positional argument:
+
+| Value | Behaviour |
+| --- | --- |
+| `http://host` or `https://host` | Card is fetched from `<URL>/.well-known/agent-card.json`. |
+| Any `http`/`https` URL ending in `.json` | Used as-is — a direct link to the agent card JSON. |
+| Any other value | Treated as a local filesystem path and read directly. |
+
+```sh
+a2a discover http://localhost:3000                        # base URL
+a2a discover https://example.com/agents/my-agent.json    # direct card URL
+a2a discover ./agent-card.json                           # local file
+```
+
+### Discover an agent
+
+```sh
+a2a discover <AGENT_REF>
+a2a discover <AGENT_REF> --extended
+```
+
+### Send a message
+
+```sh
+# One-shot — prints the completed task
+a2a send <AGENT_REF> "<message>"
+
+# With context and task identity
+a2a send <AGENT_REF> "<message>" --context-id <ctx> --task-id <task>
+
+# Streaming — prints events as they arrive
+a2a stream <AGENT_REF> "<message>"
+```
+
+### Manage tasks
+
+```sh
+a2a task get    <AGENT_REF> <TASK_ID>
+a2a task list   <AGENT_REF> [--status completed] [--context-id <ctx>]
+a2a task cancel <AGENT_REF> <TASK_ID>
+a2a task subscribe <AGENT_REF> <TASK_ID>   # stream live events
+```
+
+### Push notification configs
+
+```sh
+a2a push-config create <AGENT_REF> <TASK_ID> <CALLBACK_URL> \
+  --auth-scheme Bearer --auth-credentials <secret>
+
+a2a push-config list   <AGENT_REF> <TASK_ID>
+a2a push-config get    <AGENT_REF> <TASK_ID> <CONFIG_ID>
+a2a push-config delete <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+## Global flags
+
+| Flag | Env var | Description |
+| --- | --- | --- |
+| `--enabled-binding jsonrpc\|http-json` | | Pin the transport binding. Repeatable. Auto-negotiated if omitted. |
+| `--bearer-token <TOKEN>` | `A2A_BEARER_TOKEN` | Bearer token sent with every request. |
+| `--header <Name:Value>` | | Custom HTTP header. Repeatable. |
+| `-o pretty\|json` | | Output format. `pretty` = indented JSON (default). `json` = compact, one object per line. |
+
+## Config file
+
+Create `.a2a.yaml` in any ancestor directory (up to `$HOME`) to set defaults:
+
+```yaml
+enabled_bindings:
+  - http-json
+bearer_token: my-token
+headers:
+  - "X-Tenant: acme"
+output: json
+```
+
+CLI flags always win over config file values. Headers are additive.
+
+## Pipe-friendly output
+
+Use `-o json` with `jq` for scripting:
+
+```sh
+# Get the agent name
+a2a -o json discover http://localhost:3000 | jq -r '.name'
+
+# Watch task state from a stream
+a2a -o json stream http://localhost:3000 "hello" | jq -r '.statusUpdate.status.state // empty'
+
+# List completed task IDs
+a2a -o json task list http://localhost:3000 --status completed | jq -r '.tasks[].id'
+```
+
+## Reference
+
+Full documentation: [`a2acli/README.md`](../a2acli/README.md)

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 name = "a2acli"
 
 [[bin]]
-name = "a2acli"
+name = "a2a"
 path = "src/main.rs"
 
 [dependencies]

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
@@ -36,3 +37,4 @@ a2a-server = { workspace = true }
 assert_cmd = "2"
 async-trait = { workspace = true }
 axum = { workspace = true }
+tempfile = "3"

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -1,45 +1,296 @@
 # a2acli
 
-Standalone A2A CLI client built on top of `a2a-client`.
-
-This crate is published as `a2a-cli` and installs the `a2acli` binary.
+Standalone A2A CLI client built on top of `a2a-client`. Published as `a2a-cli`; installs the `a2a` binary.
 
 ## Install
 
-From the workspace checkout:
+**macOS** — [Homebrew](https://brew.sh):
 
 ```sh
-cargo install --path a2acli
+brew tap a2aproject/a2a-rs https://github.com/a2aproject/a2a-rs
+brew trust a2aproject/a2a-rs
+brew install a2acli
 ```
 
-From crates.io after release:
+**Linux** — install script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/a2aproject/a2a-rs/main/install.sh | bash
+```
+
+Installs to `/usr/local/bin` as root or `~/.local/bin` otherwise. Override the destination with `A2A_CLI_INSTALL_DIR`.
+
+**Windows** — [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
+
+```sh
+winget install a2aproject.a2acli
+```
+
+**From source** — via [crates.io](https://crates.io/crates/a2a-cli):
 
 ```sh
 cargo install a2a-cli
 ```
 
-## What It Provides
-
-- Fetch and print the public agent card for an A2A deployment
-- Send one-shot or streaming messages
-- Inspect, list, cancel, and subscribe to tasks
-- Create, fetch, list, and delete task push notification configs
-- Request an extended agent card when the server exposes one
-- Add bearer-token or custom-header authentication to all requests
-
-## Run
+**From workspace checkout:**
 
 ```sh
-cargo run --bin a2acli -- card
-cargo run --bin a2acli -- send "hello from rust"
-cargo run --bin a2acli -- stream "hello from rust"
-cargo run --bin a2acli -- get-task task-123
-cargo run --bin a2acli -- push-config list task-123
-cargo run --bin a2acli -- push-config create task-123 https://example.com/callback --auth-scheme Bearer --auth-credentials secret
+cargo install --path a2acli
 ```
 
-By default the CLI targets `http://localhost:3000`. Use `--base-url` to point at
-another deployment and `--binding jsonrpc` or `--binding http-json` to pin the
-transport when the agent card exposes more than one compatible interface. The
-global `--tenant`, `--bearer-token`, and repeated `--header Name:Value` options
-also apply to push-config commands.
+## Quick start
+
+Every command takes an `AGENT_REF` as its first positional argument. This can be:
+
+- A base URL — the card is fetched from `<URL>/.well-known/agent-card.json`
+- A direct URL ending in `.json` — used as-is
+- A local file path — read from disk
+
+```sh
+# Base URL
+a2a discover http://localhost:3000
+
+# Direct URL to a card JSON
+a2a discover https://example.com/agents/my-agent.json
+
+# Local file
+a2a discover ./agent-card.json
+
+# Send a message (same AGENT_REF forms apply to all commands)
+a2a send http://localhost:3000 "hello"
+a2a stream http://localhost:3000 "hello"
+a2a task list http://localhost:3000
+a2a task get http://localhost:3000 <task-id>
+```
+
+## Global options
+
+These options apply to every subcommand.
+
+| Flag | Env var | Description |
+| --- | --- | --- |
+| `--enabled-binding <BINDING>` | | Pin the transport. `jsonrpc` or `http-json`. Repeatable. Auto-negotiated from the agent card if omitted. |
+| `--bearer-token <TOKEN>` | `A2A_BEARER_TOKEN` | Adds `Authorization: Bearer <TOKEN>` to all requests. |
+| `--header <Name:Value>` | | Adds a custom HTTP header to all requests. Repeatable. |
+| `-o, --output <FORMAT>` | | Output format: `pretty` (default, indented JSON) or `json` (compact, one object per line). |
+
+## Config file
+
+The CLI searches for `.a2a.yaml` starting from the current directory and walking up to `$HOME`. You can also place one in `$HOME/.a2a.yaml` as a fallback. CLI flags always override config file values; headers are additive (config headers come first, then CLI headers).
+
+```yaml
+# .a2a.yaml
+enabled_bindings:
+  - http-json          # jsonrpc | http-json
+bearer_token: my-token
+headers:
+  - "X-Tenant: acme"
+output: json           # pretty | json
+```
+
+## Commands
+
+### `discover`
+
+Fetch and print an agent's public card (or extended card with `--extended`).
+
+```sh
+a2a discover <AGENT_REF> [--extended]
+```
+
+`AGENT_REF` is resolved as follows:
+
+| Value | Behaviour |
+| --- | --- |
+| `http://host` or `https://host` | Appends `/.well-known/agent-card.json` and fetches it. |
+| Any `http`/`https` URL ending in `.json` | Used as-is — a direct link to the agent card JSON. |
+| Any other value | Treated as a local filesystem path and read directly. |
+
+```sh
+# Base URL — card is fetched from /.well-known/agent-card.json
+a2a discover http://localhost:3000
+
+# Direct URL to the card JSON
+a2a discover https://example.com/cards/my-agent.json
+
+# Local file
+a2a discover ./agent-card.json
+a2a discover /etc/a2a/staging-card.json
+
+# Extended card (requires the agent to support it)
+a2a discover http://localhost:3000 --extended
+```
+
+### `send`
+
+Send a one-shot message and print the resulting task.
+
+```sh
+a2a send <AGENT_REF> <TEXT> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--context-id <ID>` | Attach the message to an existing context. |
+| `--task-id <ID>` | Attach the message to an existing task. |
+| `--history-length <N>` | Number of history turns to request. |
+| `--accept-output <MIME>` | Accepted output modes. Repeatable. |
+| `--return-immediately` | Ask the agent to return immediately without waiting for completion. |
+
+```sh
+a2a send http://localhost:3000 "summarise this report"
+a2a send http://localhost:3000 "continue" --task-id task-abc --context-id ctx-1
+a2a send http://localhost:3000 "export" --accept-output text/plain --accept-output application/pdf
+```
+
+### `stream`
+
+Send a message and stream the response events. Each event is printed as it arrives.
+
+```sh
+a2a stream <AGENT_REF> <TEXT> [OPTIONS]
+```
+
+Accepts the same options as `send` except `--return-immediately`.
+
+```sh
+a2a stream http://localhost:3000 "write me a blog post"
+a2a -o json stream http://localhost:3000 "hello" --task-id task-abc
+```
+
+Use `-o json` to get one JSON object per line, which is convenient for piping to `jq`.
+
+### `task`
+
+Manage tasks on an agent.
+
+#### `task get`
+
+```sh
+a2a task get <AGENT_REF> <TASK_ID> [--history-length <N>]
+```
+
+#### `task list`
+
+```sh
+a2a task list <AGENT_REF> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--context-id <ID>` | Filter by context. |
+| `--status <STATE>` | Filter by state. Values: `submitted`, `working`, `completed`, `failed`, `canceled`, `input-required`, `rejected`, `auth-required`. |
+| `--page-size <N>` | Maximum number of tasks to return. |
+| `--page-token <TOKEN>` | Pagination cursor from a previous response. |
+| `--history-length <N>` | Number of history turns to include. |
+| `--include-artifacts` | Include task artifacts in the response. |
+
+```sh
+a2a task list http://localhost:3000
+a2a task list http://localhost:3000 --status completed --context-id ctx-1
+```
+
+#### `task cancel`
+
+```sh
+a2a task cancel <AGENT_REF> <TASK_ID>
+```
+
+#### `task subscribe`
+
+Stream live status-update events for a task until it reaches a terminal state.
+
+```sh
+a2a task subscribe <AGENT_REF> <TASK_ID>
+```
+
+```sh
+a2a -o json task subscribe http://localhost:3000 task-abc | jq '.statusUpdate.status.state'
+```
+
+### `push-config`
+
+Manage push notification configs for tasks.
+
+#### `push-config create`
+
+```sh
+a2a push-config create <AGENT_REF> <TASK_ID> <CALLBACK_URL> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--config-id <ID>` | Assign a specific ID to the config (server-generated if omitted). |
+| `--token <TOKEN>` | Opaque token forwarded in push notifications. |
+| `--auth-scheme <SCHEME>` | Authentication scheme for the callback (e.g. `Bearer`). Requires `--auth-credentials`. |
+| `--auth-credentials <CREDS>` | Credentials for the callback endpoint. Requires `--auth-scheme`. |
+
+```sh
+a2a push-config create http://localhost:3000 task-abc https://my.service/webhook \
+  --config-id cfg-1 \
+  --auth-scheme Bearer \
+  --auth-credentials my-secret
+```
+
+#### `push-config get`
+
+```sh
+a2a push-config get <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+#### `push-config list`
+
+```sh
+a2a push-config list <AGENT_REF> <TASK_ID> [--page-size <N>] [--page-token <TOKEN>]
+```
+
+#### `push-config delete`
+
+```sh
+a2a push-config delete <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+## Authentication
+
+### Bearer token
+
+```sh
+# via flag
+a2a --bearer-token my-token discover http://localhost:3000
+
+# via environment variable
+export A2A_BEARER_TOKEN=my-token
+a2a discover http://localhost:3000
+```
+
+### Custom headers
+
+```sh
+a2a --header "X-Api-Key: secret" --header "X-Tenant: acme" send http://localhost:3000 "hello"
+```
+
+## Output format
+
+By default responses are printed as indented (pretty-printed) JSON. Pass `-o json` for compact, one-object-per-line output.
+
+```sh
+# Pretty (default)
+a2a discover http://localhost:3000
+
+# Compact — pipe-friendly
+a2a -o json discover http://localhost:3000 | jq '.name'
+
+# Streaming compact — one event per line
+a2a -o json stream http://localhost:3000 "hello" | jq '.statusUpdate.status.state'
+```
+
+## Transport negotiation
+
+By default the CLI reads the agent card, discovers the supported interfaces, and picks a binding automatically (preferring JSON-RPC). Use `--enabled-binding` to restrict which binding is considered:
+
+```sh
+a2a --enabled-binding http-json send http://localhost:3000 "hello"
+a2a --enabled-binding jsonrpc   send http://localhost:3000 "hello"
+```
+
+`--enabled-binding` may be repeated; the CLI will use whichever of those bindings the agent card also advertises.

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -37,7 +37,11 @@ const CONFIG_FILENAME: &str = ".a2a.yaml";
 pub fn find_config_file() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let home = home_dir();
-    find_config_file_from(&cwd, home.as_deref())
+    find_config_file_from(&cwd, home.as_deref()).or_else(|| {
+        home.as_ref()
+            .map(|h| h.join(CONFIG_FILENAME))
+            .filter(|p| p.is_file())
+    })
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -129,8 +133,6 @@ fn parse_binding_str(s: &str) -> Option<Binding> {
     match s {
         "jsonrpc" => Some(Binding::Jsonrpc),
         "http-json" => Some(Binding::HttpJson),
-        #[cfg(feature = "slimrpc")]
-        "slimrpc" => Some(Binding::Slimrpc),
         _ => None,
     }
 }

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -1,0 +1,298 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::{Cli, HeaderArg, OutputFormat, Transport};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(default)]
+    pub transports: Vec<String>,
+    #[serde(default)]
+    pub bearer_token: Option<String>,
+    #[serde(default)]
+    pub headers: Vec<String>,
+    #[serde(default)]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read {0}: {1}")]
+    Io(PathBuf, std::io::Error),
+    #[error("failed to parse {0}: {1}")]
+    Parse(PathBuf, serde_yaml::Error),
+    #[error("invalid value in {0}: {1}")]
+    Invalid(PathBuf, String),
+}
+
+const CONFIG_FILENAME: &str = ".a2a.yaml";
+
+pub fn find_config_file() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let home = home_dir();
+    find_config_file_from(&cwd, home.as_deref())
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn find_config_file_from(start: &Path, home: Option<&Path>) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let candidate = dir.join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if home.is_some_and(|h| dir == h) {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => break,
+        }
+    }
+    None
+}
+
+pub fn load_config() -> Result<(Config, Option<PathBuf>), ConfigError> {
+    match find_config_file() {
+        Some(path) => {
+            let file = File::open(&path).map_err(|e| ConfigError::Io(path.clone(), e))?;
+            let config: Config = serde_yaml::from_reader(BufReader::new(file))
+                .map_err(|e| ConfigError::Parse(path.clone(), e))?;
+            Ok((config, Some(path)))
+        }
+        None => Ok((Config::default(), None)),
+    }
+}
+
+pub fn apply_config(
+    cli: &mut Cli,
+    config: &Config,
+    path: &Option<PathBuf>,
+) -> Result<(), ConfigError> {
+    let placeholder = PathBuf::from("<config>");
+    let p = path.as_ref().unwrap_or(&placeholder);
+
+    // Transports: CLI wins if any flags were given
+    if cli.transports.is_empty() && !config.transports.is_empty() {
+        for s in &config.transports {
+            let transport = parse_transport_str(s).ok_or_else(|| {
+                ConfigError::Invalid(p.clone(), format!("unknown transport: {s:?}"))
+            })?;
+            cli.transports.push(transport);
+        }
+    }
+
+    // Bearer token: CLI wins
+    if cli.bearer_token.is_none() {
+        cli.bearer_token = config.bearer_token.clone();
+    }
+
+    // Headers: additive — config headers first, then CLI headers
+    if !config.headers.is_empty() {
+        let mut config_headers: Vec<HeaderArg> = Vec::new();
+        for s in &config.headers {
+            let h = crate::parse_header(s).map_err(|e| {
+                ConfigError::Invalid(p.clone(), format!("invalid header {s:?}: {e}"))
+            })?;
+            config_headers.push(h);
+        }
+        config_headers.append(&mut cli.headers);
+        cli.headers = config_headers;
+    }
+
+    // Output: config only fills in if CLI didn't specify
+    if cli.output.is_none() {
+        if let Some(s) = &config.output {
+            let fmt = parse_output_format(s).ok_or_else(|| {
+                ConfigError::Invalid(p.clone(), format!("unknown output format: {s:?}"))
+            })?;
+            cli.output = Some(fmt);
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_transport_str(s: &str) -> Option<Transport> {
+    match s {
+        "jsonrpc" => Some(Transport::Jsonrpc),
+        "http-json" => Some(Transport::HttpJson),
+        #[cfg(feature = "slimrpc")]
+        "slimrpc" => Some(Transport::Slimrpc),
+        _ => None,
+    }
+}
+
+fn parse_output_format(s: &str) -> Option<OutputFormat> {
+    match s {
+        "pretty" => Some(OutputFormat::Pretty),
+        "json" => Some(OutputFormat::Json),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{OutputFormat, Transport};
+
+    fn parse_config(yaml: &str) -> Config {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    fn empty_cli() -> Cli {
+        use crate::Command;
+        Cli {
+            transports: vec![],
+            bearer_token: None,
+            headers: vec![],
+            output: None,
+            command: Command::Discover(crate::DiscoverCommand {
+                agent_ref: "http://localhost".to_string(),
+                extended: false,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_find_config_in_start_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+        assert_eq!(find_config_file_from(dir.path(), None), Some(cfg));
+    }
+
+    #[test]
+    fn test_find_config_walks_up() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = root.path().to_path_buf();
+        let child = parent.join("child");
+        std::fs::create_dir(&child).unwrap();
+
+        let cfg = parent.join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(find_config_file_from(&child, None), Some(cfg));
+    }
+
+    #[test]
+    fn test_find_config_stops_at_home() {
+        let home = tempfile::tempdir().unwrap();
+        let above = home.path().parent().unwrap().to_path_buf();
+        // Put config above home — should NOT be found
+        std::fs::write(above.join(".a2a.yaml"), "").unwrap();
+        assert_eq!(
+            find_config_file_from(home.path(), Some(home.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_config_found_at_home() {
+        let home = tempfile::tempdir().unwrap();
+        let cfg = home.path().join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+        assert_eq!(
+            find_config_file_from(home.path(), Some(home.path())),
+            Some(cfg)
+        );
+    }
+
+    #[test]
+    fn test_find_config_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(find_config_file_from(dir.path(), Some(dir.path())), None);
+    }
+
+    #[test]
+    fn test_parse_valid_config() {
+        let cfg = parse_config("transports:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
+        assert_eq!(cfg.transports, vec!["jsonrpc"]);
+        assert_eq!(cfg.bearer_token.as_deref(), Some("tok"));
+        assert_eq!(cfg.output.as_deref(), Some("json"));
+    }
+
+    #[test]
+    fn test_unknown_field_is_rejected() {
+        let result = serde_yaml::from_str::<Config>("typo_field: value");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_fills_empty_cli() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("transports:\n  - http-json\nbearer_token: tok\noutput: json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.transports, vec![crate::Transport::HttpJson]);
+        assert_eq!(cli.bearer_token.as_deref(), Some("tok"));
+        assert_eq!(cli.output, Some(OutputFormat::Json));
+    }
+
+    #[test]
+    fn test_cli_transports_take_precedence() {
+        let mut cli = empty_cli();
+        cli.transports = vec![Transport::Jsonrpc];
+        let cfg = parse_config("transports:\n  - http-json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.transports, vec![Transport::Jsonrpc]);
+    }
+
+    #[test]
+    fn test_headers_are_additive() {
+        let mut cli = empty_cli();
+        cli.headers = vec![HeaderArg {
+            name: "X-Cli".to_string(),
+            value: "cli".to_string(),
+        }];
+        let cfg = parse_config("headers:\n  - \"X-Config: cfg\"\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.headers.len(), 2);
+        assert_eq!(cli.headers[0].name, "X-Config");
+        assert_eq!(cli.headers[1].name, "X-Cli");
+    }
+
+    #[test]
+    fn test_invalid_transport_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("transports:\n  - bogus\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("unknown transport"));
+    }
+
+    #[test]
+    fn test_invalid_output_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("output: bogus\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("unknown output format"));
+    }
+
+    #[test]
+    fn test_invalid_header_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("headers:\n  - \"no-colon\"\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("invalid header"));
+    }
+
+    #[test]
+    fn test_cli_output_takes_precedence() {
+        let mut cli = empty_cli();
+        cli.output = Some(OutputFormat::Pretty);
+        let cfg = parse_config("output: json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.output, Some(OutputFormat::Pretty));
+    }
+}

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -7,13 +7,13 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::{Cli, HeaderArg, OutputFormat, Transport};
+use crate::{Binding, Cli, HeaderArg, OutputFormat};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
-    pub transports: Vec<String>,
+    pub enabled_bindings: Vec<String>,
     #[serde(default)]
     pub bearer_token: Option<String>,
     #[serde(default)]
@@ -84,13 +84,13 @@ pub fn apply_config(
     let placeholder = PathBuf::from("<config>");
     let p = path.as_ref().unwrap_or(&placeholder);
 
-    // Transports: CLI wins if any flags were given
-    if cli.transports.is_empty() && !config.transports.is_empty() {
-        for s in &config.transports {
-            let transport = parse_transport_str(s).ok_or_else(|| {
+    // Enabled bindings: CLI wins if any flags were given
+    if cli.enabled_bindings.is_empty() && !config.enabled_bindings.is_empty() {
+        for s in &config.enabled_bindings {
+            let binding = parse_binding_str(s).ok_or_else(|| {
                 ConfigError::Invalid(p.clone(), format!("unknown transport: {s:?}"))
             })?;
-            cli.transports.push(transport);
+            cli.enabled_bindings.push(binding);
         }
     }
 
@@ -125,12 +125,12 @@ pub fn apply_config(
     Ok(())
 }
 
-fn parse_transport_str(s: &str) -> Option<Transport> {
+fn parse_binding_str(s: &str) -> Option<Binding> {
     match s {
-        "jsonrpc" => Some(Transport::Jsonrpc),
-        "http-json" => Some(Transport::HttpJson),
+        "jsonrpc" => Some(Binding::Jsonrpc),
+        "http-json" => Some(Binding::HttpJson),
         #[cfg(feature = "slimrpc")]
-        "slimrpc" => Some(Transport::Slimrpc),
+        "slimrpc" => Some(Binding::Slimrpc),
         _ => None,
     }
 }
@@ -146,7 +146,7 @@ fn parse_output_format(s: &str) -> Option<OutputFormat> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{OutputFormat, Transport};
+    use crate::{Binding, OutputFormat};
 
     fn parse_config(yaml: &str) -> Config {
         serde_yaml::from_str(yaml).unwrap()
@@ -155,7 +155,7 @@ mod tests {
     fn empty_cli() -> Cli {
         use crate::Command;
         Cli {
-            transports: vec![],
+            enabled_bindings: vec![],
             bearer_token: None,
             headers: vec![],
             output: None,
@@ -218,8 +218,8 @@ mod tests {
 
     #[test]
     fn test_parse_valid_config() {
-        let cfg = parse_config("transports:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
-        assert_eq!(cfg.transports, vec!["jsonrpc"]);
+        let cfg = parse_config("enabled_bindings:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
+        assert_eq!(cfg.enabled_bindings, vec!["jsonrpc"]);
         assert_eq!(cfg.bearer_token.as_deref(), Some("tok"));
         assert_eq!(cfg.output.as_deref(), Some("json"));
     }
@@ -233,20 +233,20 @@ mod tests {
     #[test]
     fn test_apply_fills_empty_cli() {
         let mut cli = empty_cli();
-        let cfg = parse_config("transports:\n  - http-json\nbearer_token: tok\noutput: json\n");
+        let cfg = parse_config("enabled_bindings:\n  - http-json\nbearer_token: tok\noutput: json\n");
         apply_config(&mut cli, &cfg, &None).unwrap();
-        assert_eq!(cli.transports, vec![crate::Transport::HttpJson]);
+        assert_eq!(cli.enabled_bindings, vec![crate::Binding::HttpJson]);
         assert_eq!(cli.bearer_token.as_deref(), Some("tok"));
         assert_eq!(cli.output, Some(OutputFormat::Json));
     }
 
     #[test]
-    fn test_cli_transports_take_precedence() {
+    fn test_cli_bindings_take_precedence() {
         let mut cli = empty_cli();
-        cli.transports = vec![Transport::Jsonrpc];
-        let cfg = parse_config("transports:\n  - http-json\n");
+        cli.enabled_bindings = vec![Binding::Jsonrpc];
+        let cfg = parse_config("enabled_bindings:\n  - http-json\n");
         apply_config(&mut cli, &cfg, &None).unwrap();
-        assert_eq!(cli.transports, vec![Transport::Jsonrpc]);
+        assert_eq!(cli.enabled_bindings, vec![Binding::Jsonrpc]);
     }
 
     #[test]
@@ -264,9 +264,9 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_transport_errors() {
+    fn test_invalid_binding_errors() {
         let mut cli = empty_cli();
-        let cfg = parse_config("transports:\n  - bogus\n");
+        let cfg = parse_config("enabled_bindings:\n  - bogus\n");
         let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
         assert!(err.to_string().contains("unknown transport"));
     }

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -1,6 +1,8 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(not(test))]
 use std::fs::File;
+#[cfg(not(test))]
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
@@ -34,6 +36,7 @@ pub enum ConfigError {
 
 const CONFIG_FILENAME: &str = ".a2a.yaml";
 
+#[cfg(not(test))]
 pub fn find_config_file() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let home = home_dir();
@@ -44,6 +47,7 @@ pub fn find_config_file() -> Option<PathBuf> {
     })
 }
 
+#[cfg(not(test))]
 fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
@@ -68,6 +72,7 @@ fn find_config_file_from(start: &Path, home: Option<&Path>) -> Option<PathBuf> {
     None
 }
 
+#[cfg(not(test))]
 pub fn load_config() -> Result<(Config, Option<PathBuf>), ConfigError> {
     match find_config_file() {
         Some(path) => {

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -12,15 +12,13 @@ use serde::Serialize;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Parser, PartialEq, Eq)]
-#[command(name = "a2acli", version, about = "Standalone A2A client CLI")]
+#[command(name = "a2a", version, about = "A2A client CLI")]
 pub struct Cli {
-    /// Base URL used to resolve /.well-known/agent-card.json.
-    #[arg(long, global = true, default_value = "http://localhost:3000")]
-    pub base_url: String,
-
-    /// Prefer a specific transport when the agent card exposes multiple bindings.
-    #[arg(long, global = true, value_enum)]
-    pub binding: Option<Binding>,
+    /// Enabled transports in preference order (first = most preferred).
+    /// Repeat the flag to enable multiple transports, e.g. --transport jsonrpc --transport http-json.
+    /// Only transports listed here will be used; the order overrides the server's preference.
+    #[arg(long = "transport", global = true, value_enum)]
+    pub transports: Vec<Transport>,
 
     /// Bearer token attached to the agent-card fetch and client calls.
     #[arg(long, global = true, env = "A2A_BEARER_TOKEN")]
@@ -34,32 +32,35 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub tenant: Option<String>,
 
-    /// Emit compact JSON instead of pretty-printed JSON.
-    #[arg(long, global = true)]
-    pub compact: bool,
+    /// Output format.
+    #[arg(long, short = 'o', global = true, value_enum, default_value = "pretty")]
+    pub output: OutputFormat,
 
     #[command(subcommand)]
     pub command: Command,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// Pretty-printed JSON.
+    Pretty,
+    /// Compact JSON (one object per line for streaming commands).
+    Json,
+}
+
 #[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
 pub enum Command {
-    /// Fetch and print the public agent card.
-    Card,
-    /// Fetch and print the extended agent card.
-    ExtendedCard,
-    /// Send a one-shot message.
-    Send(MessageCommand),
+    /// Fetch and print an agent's card.
+    Discover(DiscoverCommand),
+    /// Send a one-shot message to an agent.
+    Send(SendCommand),
     /// Send a streaming message and print each event as it arrives.
-    Stream(MessageCommand),
-    /// Fetch a task by ID.
-    GetTask(TaskLookupCommand),
-    /// List tasks with optional filters.
-    ListTasks(ListTasksCommand),
-    /// Cancel a task by ID.
-    CancelTask(TaskIdCommand),
-    /// Subscribe to task updates and print each event as it arrives.
-    Subscribe(TaskIdCommand),
+    Stream(StreamCommand),
+    /// Task lifecycle operations.
+    Task {
+        #[command(subcommand)]
+        command: TaskCommand,
+    },
     /// Manage push notification configs for a task.
     PushConfig {
         #[command(subcommand)]
@@ -68,7 +69,20 @@ pub enum Command {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct MessageCommand {
+pub struct DiscoverCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Fetch the extended agent card instead of the public one.
+    #[arg(long)]
+    pub extended: bool,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct SendCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Text payload to send as the user message.
     pub text: String,
 
@@ -94,7 +108,47 @@ pub struct MessageCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct TaskLookupCommand {
+pub struct StreamCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Text payload to send as the user message.
+    pub text: String,
+
+    /// Optional context identifier to continue an existing conversation.
+    #[arg(long)]
+    pub context_id: Option<String>,
+
+    /// Optional task identifier to continue an existing task.
+    #[arg(long)]
+    pub task_id: Option<String>,
+
+    /// Ask the server to include up to this many history items in task responses.
+    #[arg(long)]
+    pub history_length: Option<i32>,
+
+    /// Accepted output mode, for example text/plain or application/json.
+    #[arg(long = "accept-output")]
+    pub accepted_output_modes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
+pub enum TaskCommand {
+    /// Fetch a task by ID.
+    Get(TaskGetCommand),
+    /// List tasks with optional filters.
+    List(TaskListCommand),
+    /// Cancel a task by ID.
+    Cancel(TaskCancelCommand),
+    /// Subscribe to task updates and print each event as it arrives.
+    Subscribe(TaskSubscribeCommand),
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskGetCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub id: String,
 
@@ -104,7 +158,10 @@ pub struct TaskLookupCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct ListTasksCommand {
+pub struct TaskListCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Filter by context identifier.
     #[arg(long)]
     pub context_id: Option<String>,
@@ -131,7 +188,19 @@ pub struct ListTasksCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct TaskIdCommand {
+pub struct TaskCancelCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Task identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskSubscribeCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub id: String,
 }
@@ -141,15 +210,18 @@ pub enum PushConfigCommand {
     /// Create a push notification config for a task.
     Create(CreatePushConfigCommand),
     /// Fetch a push notification config by ID.
-    Get(PushConfigIdCommand),
+    Get(PushConfigGetCommand),
     /// List push notification configs for a task.
-    List(ListPushConfigsCommand),
+    List(PushConfigListCommand),
     /// Delete a push notification config by ID.
-    Delete(PushConfigIdCommand),
+    Delete(PushConfigDeleteCommand),
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 pub struct CreatePushConfigCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -174,7 +246,10 @@ pub struct CreatePushConfigCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct PushConfigIdCommand {
+pub struct PushConfigGetCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -183,7 +258,22 @@ pub struct PushConfigIdCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct ListPushConfigsCommand {
+pub struct PushConfigDeleteCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Task identifier.
+    pub task_id: String,
+
+    /// Push config identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct PushConfigListCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -203,19 +293,21 @@ pub struct HeaderArg {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum Binding {
+pub enum Transport {
     Jsonrpc,
     HttpJson,
 }
 
-impl Binding {
+impl Transport {
     fn protocol(self) -> &'static str {
         match self {
-            Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
-            Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+            Transport::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
+            Transport::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
         }
     }
 }
+
+const DEFAULT_TRANSPORTS: &[Transport] = &[Transport::Jsonrpc, Transport::HttpJson];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum TaskStateArg {
@@ -254,102 +346,58 @@ pub enum CliError {
     Http(#[from] reqwest::Error),
     #[error("failed to serialize output: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("failed to read file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid agent card: {reason}")]
+    InvalidAgentCard { reason: String },
     #[error("invalid input: {0}")]
     InvalidInput(String),
 }
 
 pub async fn run(cli: Cli) -> Result<(), CliError> {
+    let compact = cli.output == OutputFormat::Json;
+
     match &cli.command {
-        Command::Card => {
-            let card = resolve_agent_card(&cli).await?;
-            print_json(&card, cli.compact)?;
-        }
-        Command::ExtendedCard => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .get_extended_agent_card(&GetExtendedAgentCardRequest {
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let card = finish_client_call(client, result).await?;
-            print_json(&card, cli.compact)?;
+        Command::Discover(command) => {
+            if command.extended {
+                let client = resolve_client(&command.agent_ref, &cli).await?;
+                let result = client
+                    .get_extended_agent_card(&GetExtendedAgentCardRequest {
+                        tenant: cli.tenant.clone(),
+                    })
+                    .await;
+                let card = finish_client_call(client, result).await?;
+                print_json(&card, compact)?;
+            } else {
+                let card = resolve_agent_card(&command.agent_ref, &cli).await?;
+                print_json(&card, compact)?;
+            }
         }
         Command::Send(command) => {
             let request = build_send_message_request(command, cli.tenant.clone());
-            let client = resolve_client(&cli).await?;
+            let client = resolve_client(&command.agent_ref, &cli).await?;
             let result = client.send_message(&request).await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         Command::Stream(command) => {
-            let client = resolve_client(&cli).await?;
-            let request = build_send_message_request(command, cli.tenant.clone());
+            let client = resolve_client(&command.agent_ref, &cli).await?;
+            let request = build_stream_message_request(command, cli.tenant.clone());
             let stream = client.send_streaming_message(&request).await?;
-            consume_stream(client, stream, cli.compact).await?;
+            consume_stream(client, stream, compact).await?;
         }
-        Command::GetTask(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .get_task(&GetTaskRequest {
-                    id: command.id.clone(),
-                    history_length: command.history_length,
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let task = finish_client_call(client, result).await?;
-            print_json(&task, cli.compact)?;
-        }
-        Command::ListTasks(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .list_tasks(&ListTasksRequest {
-                    context_id: command.context_id.clone(),
-                    status: command.status.map(TaskState::from),
-                    page_size: command.page_size,
-                    page_token: command.page_token.clone(),
-                    history_length: command.history_length,
-                    status_timestamp_after: None,
-                    include_artifacts: command.include_artifacts.then_some(true),
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
-        }
-        Command::CancelTask(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .cancel_task(&CancelTaskRequest {
-                    id: command.id.clone(),
-                    metadata: None,
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let task = finish_client_call(client, result).await?;
-            print_json(&task, cli.compact)?;
-        }
-        Command::Subscribe(command) => {
-            let client = resolve_client(&cli).await?;
-            let stream = client
-                .subscribe_to_task(&SubscribeToTaskRequest {
-                    id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
-                })
-                .await?;
-            consume_stream(client, stream, cli.compact).await?;
+        Command::Task { command } => {
+            run_task_command(&cli, command, compact).await?;
         }
         Command::PushConfig { command } => {
-            run_push_config_command(&cli, command).await?;
+            run_push_config_command(&cli, command, compact).await?;
         }
     }
 
     Ok(())
 }
 
-fn build_send_message_request(
-    command: &MessageCommand,
-    tenant: Option<String>,
-) -> SendMessageRequest {
+fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -375,6 +423,97 @@ fn build_send_message_request(
         metadata: None,
         tenant,
     }
+}
+
+fn build_stream_message_request(
+    command: &StreamCommand,
+    tenant: Option<String>,
+) -> SendMessageRequest {
+    let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
+    message.context_id = command.context_id.clone();
+    message.task_id = command.task_id.clone();
+
+    let configuration = if command.history_length.is_some()
+        || !command.accepted_output_modes.is_empty()
+    {
+        Some(SendMessageConfiguration {
+            accepted_output_modes: (!command.accepted_output_modes.is_empty())
+                .then_some(command.accepted_output_modes.clone()),
+            task_push_notification_config: None,
+            history_length: command.history_length,
+            return_immediately: None,
+        })
+    } else {
+        None
+    };
+
+    SendMessageRequest {
+        message,
+        configuration,
+        metadata: None,
+        tenant,
+    }
+}
+
+async fn run_task_command(
+    cli: &Cli,
+    command: &TaskCommand,
+    compact: bool,
+) -> Result<(), CliError> {
+    match command {
+        TaskCommand::Get(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .get_task(&GetTaskRequest {
+                    id: command.id.clone(),
+                    history_length: command.history_length,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, compact)?;
+        }
+        TaskCommand::List(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .list_tasks(&ListTasksRequest {
+                    context_id: command.context_id.clone(),
+                    status: command.status.map(TaskState::from),
+                    page_size: command.page_size,
+                    page_token: command.page_token.clone(),
+                    history_length: command.history_length,
+                    status_timestamp_after: None,
+                    include_artifacts: command.include_artifacts.then_some(true),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, compact)?;
+        }
+        TaskCommand::Cancel(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .cancel_task(&CancelTaskRequest {
+                    id: command.id.clone(),
+                    metadata: None,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, compact)?;
+        }
+        TaskCommand::Subscribe(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let stream = client
+                .subscribe_to_task(&SubscribeToTaskRequest {
+                    id: command.id.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await?;
+            consume_stream(client, stream, compact).await?;
+        }
+    }
+    Ok(())
 }
 
 fn build_push_notification_config(
@@ -404,19 +543,23 @@ fn build_push_notification_config(
     })
 }
 
-async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Result<(), CliError> {
+async fn run_push_config_command(
+    cli: &Cli,
+    command: &PushConfigCommand,
+    compact: bool,
+) -> Result<(), CliError> {
     match command {
         PushConfigCommand::Create(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
             config.tenant = cli.tenant.clone();
             let result = client.create_push_config(&config).await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::Get(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .get_push_config(&GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
@@ -425,10 +568,10 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::List(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .list_push_configs(&ListTaskPushNotificationConfigsRequest {
                     task_id: command.task_id.clone(),
@@ -438,10 +581,10 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::Delete(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
@@ -456,7 +599,7 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                     "taskId": command.task_id,
                     "id": command.id,
                 }),
-                cli.compact,
+                compact,
             )?;
         }
     }
@@ -464,13 +607,25 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
     Ok(())
 }
 
-async fn resolve_client(cli: &Cli) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
-    let card = resolve_agent_card(cli).await?;
+async fn resolve_client(
+    agent_ref: &str,
+    cli: &Cli,
+) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
+    let card = resolve_agent_card(agent_ref, cli).await?;
 
-    let mut builder = A2AClientFactory::builder();
-    if let Some(binding) = cli.binding {
-        builder = builder.preferred_bindings(vec![binding.protocol().to_string()]);
-    }
+    let effective_transports = if cli.transports.is_empty() {
+        DEFAULT_TRANSPORTS.to_vec()
+    } else {
+        cli.transports.clone()
+    };
+
+    let preferred: Vec<String> = effective_transports
+        .iter()
+        .map(|t| t.protocol().to_string())
+        .collect();
+
+    let mut builder = A2AClientFactory::builder().preferred_bindings(preferred);
+
     if let Some(token) = &cli.bearer_token {
         builder = builder.with_interceptor(Arc::new(AuthInterceptor::bearer(token.clone())));
     }
@@ -485,15 +640,29 @@ async fn resolve_client(cli: &Cli) -> Result<A2AClient<Box<dyn a2a_client::Trans
     Ok(factory.create_from_card(&card).await?)
 }
 
-async fn resolve_agent_card(cli: &Cli) -> Result<AgentCard, CliError> {
-    let url = format!(
-        "{}/.well-known/agent-card.json",
-        cli.base_url.trim_end_matches('/')
-    );
-    let client = Client::new();
-    let request = apply_request_auth(client.get(url), cli);
-    let response = request.send().await?.error_for_status()?;
-    Ok(response.json::<AgentCard>().await?)
+async fn resolve_agent_card(agent_ref: &str, cli: &Cli) -> Result<AgentCard, CliError> {
+    if agent_ref.starts_with("http://") || agent_ref.starts_with("https://") {
+        let url = if agent_ref.ends_with(".json") {
+            agent_ref.to_string()
+        } else {
+            format!(
+                "{}/.well-known/agent-card.json",
+                agent_ref.trim_end_matches('/')
+            )
+        };
+        let client = Client::new();
+        let request = apply_request_auth(client.get(url), cli);
+        let response = request.send().await?.error_for_status()?;
+        let body = response.text().await?;
+        serde_json::from_str(&body).map_err(|e| CliError::InvalidAgentCard {
+            reason: e.to_string(),
+        })
+    } else {
+        let json = std::fs::read_to_string(agent_ref)?;
+        serde_json::from_str(&json).map_err(|e| CliError::InvalidAgentCard {
+            reason: e.to_string(),
+        })
+    }
 }
 
 fn apply_request_auth(mut request: RequestBuilder, cli: &Cli) -> RequestBuilder {
@@ -1096,12 +1265,8 @@ mod tests {
         }
     }
 
-    fn parse_cli_with_base_url(base_url: &str, args: &[&str]) -> Cli {
-        let mut argv = vec![
-            "a2acli".to_string(),
-            "--base-url".to_string(),
-            base_url.to_string(),
-        ];
+    fn parse_cli(args: &[&str]) -> Cli {
+        let mut argv = vec!["a2a".to_string()];
         argv.extend(args.iter().map(|arg| (*arg).to_string()));
         Cli::try_parse_from(argv).unwrap()
     }
@@ -1142,7 +1307,8 @@ mod tests {
     #[test]
     fn test_build_send_message_request_populates_optional_fields() {
         let request = build_send_message_request(
-            &MessageCommand {
+            &SendCommand {
+                agent_ref: "http://localhost:3000".to_string(),
                 text: "hello".to_string(),
                 context_id: Some("ctx-1".to_string()),
                 task_id: Some("task-1".to_string()),
@@ -1176,7 +1342,8 @@ mod tests {
     #[test]
     fn test_build_send_message_request_without_optional_fields() {
         let request = build_send_message_request(
-            &MessageCommand {
+            &SendCommand {
+                agent_ref: "http://localhost:3000".to_string(),
                 text: "hello".to_string(),
                 context_id: None,
                 task_id: None,
@@ -1194,30 +1361,29 @@ mod tests {
 
     #[test]
     fn test_cli_parse_send_command() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
-            "--binding",
+        let cli = parse_cli(&[
+            "--transport",
             "jsonrpc",
             "--header",
             "X-Test:123",
             "send",
+            "http://localhost:3000",
             "hello",
             "--history-length",
             "2",
-        ])
-        .unwrap();
+        ]);
 
-        assert_eq!(cli.binding, Some(Binding::Jsonrpc));
+        assert_eq!(cli.transports, vec![crate::Transport::Jsonrpc]);
         assert_eq!(cli.headers.len(), 1);
         assert!(matches!(cli.command, Command::Send(_)));
     }
 
     #[test]
     fn test_cli_parse_push_config_create_command() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
+        let cli = parse_cli(&[
             "push-config",
             "create",
+            "http://localhost:3000",
             "task-1",
             "https://example.com/callback",
             "--config-id",
@@ -1228,13 +1394,13 @@ mod tests {
             "Bearer",
             "--auth-credentials",
             "secret",
-        ])
-        .unwrap();
+        ]);
 
         match cli.command {
             Command::PushConfig {
                 command: PushConfigCommand::Create(command),
             } => {
+                assert_eq!(command.agent_ref, "http://localhost:3000");
                 assert_eq!(command.task_id, "task-1");
                 assert_eq!(command.url, "https://example.com/callback");
                 assert_eq!(command.config_id.as_deref(), Some("cfg-1"));
@@ -1249,6 +1415,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config() {
         let config = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: Some("cfg-1".to_string()),
@@ -1279,6 +1446,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config_requires_auth_scheme() {
         let err = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: None,
@@ -1294,6 +1462,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config_without_authentication() {
         let config = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: None,
@@ -1308,22 +1477,21 @@ mod tests {
     }
 
     #[test]
-    fn test_binding_protocols() {
-        assert_eq!(Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
-        assert_eq!(Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+    fn test_transport_protocols() {
+        assert_eq!(crate::Transport::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
+        assert_eq!(crate::Transport::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
     }
 
     #[test]
     fn test_apply_request_auth_builds_headers() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
+        let cli = parse_cli(&[
             "--bearer-token",
             "secret",
             "--header",
             "X-Test: 123",
-            "card",
-        ])
-        .unwrap();
+            "discover",
+            "http://localhost:3000",
+        ]);
 
         let request = apply_request_auth(Client::new().get("http://example.com"), &cli)
             .build()
@@ -1519,109 +1687,110 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_run_executes_all_commands_in_lib_tests() {
         let server = RunTestServer::spawn().await;
+        let base_url = &server.base_url;
 
-        run(parse_cli_with_base_url(&server.base_url, &["card"]))
+        run(parse_cli(&["discover", base_url])).await.unwrap();
+        run(parse_cli(&["-o", "json", "discover", base_url, "--extended"]))
             .await
             .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "extended-card"],
-        ))
+        run(parse_cli(&[
+            "--transport",
+            "jsonrpc",
+            "--bearer-token",
+            "secret",
+            "--header",
+            "X-Test: 123",
+            "send",
+            base_url,
+            "hello from unit test",
+            "--task-id",
+            "task-send",
+            "--context-id",
+            "ctx-send",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--binding",
-                "jsonrpc",
-                "--bearer-token",
-                "secret",
-                "--header",
-                "X-Test: 123",
-                "send",
-                "hello from unit test",
-                "--task-id",
-                "task-send",
-                "--context-id",
-                "ctx-send",
-            ],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "stream",
+            base_url,
+            "streaming request",
+            "--task-id",
+            "task-stream",
+            "--context-id",
+            "ctx-stream",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--compact",
-                "stream",
-                "streaming request",
-                "--task-id",
-                "task-stream",
-                "--context-id",
-                "ctx-stream",
-            ],
-        ))
+        run(parse_cli(&["task", "get", base_url, "task-send"]))
+            .await
+            .unwrap();
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "list",
+            base_url,
+            "--context-id",
+            "ctx-send",
+            "--status",
+            "completed",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["get-task", "task-send"],
-        ))
+        run(parse_cli(&["task", "cancel", base_url, "task-send"]))
+            .await
+            .unwrap();
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "subscribe",
+            base_url,
+            "task-stream",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--compact",
-                "list-tasks",
-                "--context-id",
-                "ctx-send",
-                "--status",
-                "completed",
-            ],
-        ))
+        run(parse_cli(&[
+            "push-config",
+            "create",
+            base_url,
+            "task-1",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["cancel-task", "task-send"],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "push-config",
+            "get",
+            base_url,
+            "task-1",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "subscribe", "task-stream"],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "push-config",
+            "list",
+            base_url,
+            "task-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "push-config",
-                "create",
-                "task-1",
-                "https://example.com/callback",
-                "--config-id",
-                "cfg-1",
-            ],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "push-config", "get", "task-1", "cfg-1"],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "push-config", "list", "task-1"],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["push-config", "delete", "task-1", "cfg-1"],
-        ))
+        run(parse_cli(&[
+            "push-config",
+            "delete",
+            base_url,
+            "task-1",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
     }
@@ -1629,33 +1798,31 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_run_surfaces_errors_in_lib_tests() {
         let server = RunTestServer::spawn().await;
+        let base_url = &server.base_url;
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["extended-card", "--tenant", "error"],
-        ))
-        .await
-        .unwrap_err();
+        let err = run(parse_cli(&["discover", base_url, "--extended", "--tenant", "error"]))
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::UNSUPPORTED_OPERATION
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["send", "send-error"],
-        ))
-        .await
-        .unwrap_err();
+        let err = run(parse_cli(&["send", base_url, "send-error"]))
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::INVALID_REQUEST
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["list-tasks", "--context-id", "error"],
-        ))
+        let err = run(parse_cli(&[
+            "task",
+            "list",
+            base_url,
+            "--context-id",
+            "error",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1663,10 +1830,22 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::INVALID_PARAMS
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "stream", "stream-error"],
-        ))
+        let err = run(parse_cli(&["-o", "json", "stream", base_url, "stream-error"]))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
+        ));
+
+        let err = run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "subscribe",
+            base_url,
+            "stream-error",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1674,28 +1853,15 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "subscribe", "stream-error"],
-        ))
-        .await
-        .unwrap_err();
-        assert!(matches!(
-            err,
-            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
-        ));
-
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "push-config",
-                "create",
-                "missing",
-                "https://example.com/callback",
-                "--config-id",
-                "cfg-missing",
-            ],
-        ))
+        let err = run(parse_cli(&[
+            "push-config",
+            "create",
+            base_url,
+            "missing",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-missing",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1703,10 +1869,12 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["push-config", "list", "missing"],
-        ))
+        let err = run(parse_cli(&[
+            "push-config",
+            "list",
+            base_url,
+            "missing",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1715,7 +1883,7 @@ mod tests {
         ));
 
         let base_url = unused_base_url().await;
-        let err = run(parse_cli_with_base_url(&base_url, &["card"]))
+        let err = run(parse_cli(&["discover", &base_url]))
             .await
             .unwrap_err();
         assert!(matches!(err, CliError::Http(_)));

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+mod config;
+
 use std::sync::Arc;
 
 use a2a::*;
@@ -28,13 +30,9 @@ pub struct Cli {
     #[arg(long = "header", global = true, value_parser = parse_header)]
     pub headers: Vec<HeaderArg>,
 
-    /// Optional tenant forwarded to A2A requests that support it.
-    #[arg(long, global = true)]
-    pub tenant: Option<String>,
-
-    /// Output format.
-    #[arg(long, short = 'o', global = true, value_enum, default_value = "pretty")]
-    pub output: OutputFormat,
+    /// Output format (default: pretty).
+    #[arg(long, short = 'o', global = true, value_enum)]
+    pub output: Option<OutputFormat>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -352,19 +350,21 @@ pub enum CliError {
     InvalidAgentCard { reason: String },
     #[error("invalid input: {0}")]
     InvalidInput(String),
+    #[error("{0}")]
+    Config(#[from] config::ConfigError),
 }
 
-pub async fn run(cli: Cli) -> Result<(), CliError> {
-    let compact = cli.output == OutputFormat::Json;
+pub async fn run(mut cli: Cli) -> Result<(), CliError> {
+    let (cfg, cfg_path) = config::load_config()?;
+    config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {
         Command::Discover(command) => {
             if command.extended {
                 let client = resolve_client(&command.agent_ref, &cli).await?;
                 let result = client
-                    .get_extended_agent_card(&GetExtendedAgentCardRequest {
-                        tenant: cli.tenant.clone(),
-                    })
+                    .get_extended_agent_card(&GetExtendedAgentCardRequest { tenant: None })
                     .await;
                 let card = finish_client_call(client, result).await?;
                 print_json(&card, compact)?;
@@ -374,7 +374,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
             }
         }
         Command::Send(command) => {
-            let request = build_send_message_request(command, cli.tenant.clone());
+            let request = build_send_message_request(command);
             let client = resolve_client(&command.agent_ref, &cli).await?;
             let result = client.send_message(&request).await;
             let response = finish_client_call(client, result).await?;
@@ -382,7 +382,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
         }
         Command::Stream(command) => {
             let client = resolve_client(&command.agent_ref, &cli).await?;
-            let request = build_stream_message_request(command, cli.tenant.clone());
+            let request = build_stream_message_request(command);
             let stream = client.send_streaming_message(&request).await?;
             consume_stream(client, stream, compact).await?;
         }
@@ -397,7 +397,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
     Ok(())
 }
 
-fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> SendMessageRequest {
+fn build_send_message_request(command: &SendCommand) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -421,14 +421,11 @@ fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> 
         message,
         configuration,
         metadata: None,
-        tenant,
+        tenant: None,
     }
 }
 
-fn build_stream_message_request(
-    command: &StreamCommand,
-    tenant: Option<String>,
-) -> SendMessageRequest {
+fn build_stream_message_request(command: &StreamCommand) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -451,7 +448,7 @@ fn build_stream_message_request(
         message,
         configuration,
         metadata: None,
-        tenant,
+        tenant: None,
     }
 }
 
@@ -467,7 +464,7 @@ async fn run_task_command(
                 .get_task(&GetTaskRequest {
                     id: command.id.clone(),
                     history_length: command.history_length,
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let task = finish_client_call(client, result).await?;
@@ -484,7 +481,7 @@ async fn run_task_command(
                     history_length: command.history_length,
                     status_timestamp_after: None,
                     include_artifacts: command.include_artifacts.then_some(true),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -496,7 +493,7 @@ async fn run_task_command(
                 .cancel_task(&CancelTaskRequest {
                     id: command.id.clone(),
                     metadata: None,
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let task = finish_client_call(client, result).await?;
@@ -507,7 +504,7 @@ async fn run_task_command(
             let stream = client
                 .subscribe_to_task(&SubscribeToTaskRequest {
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await?;
             consume_stream(client, stream, compact).await?;
@@ -553,7 +550,6 @@ async fn run_push_config_command(
             let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
-            config.tenant = cli.tenant.clone();
             let result = client.create_push_config(&config).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
@@ -564,7 +560,7 @@ async fn run_push_config_command(
                 .get_push_config(&GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -577,7 +573,7 @@ async fn run_push_config_command(
                     task_id: command.task_id.clone(),
                     page_size: command.page_size,
                     page_token: command.page_token.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -589,7 +585,7 @@ async fn run_push_config_command(
                 .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             finish_client_call(client, result).await?;
@@ -684,7 +680,7 @@ fn print_json<T: Serialize>(value: &T, compact: bool) -> Result<(), CliError> {
     Ok(())
 }
 
-fn parse_header(input: &str) -> Result<HeaderArg, String> {
+pub(crate) fn parse_header(input: &str) -> Result<HeaderArg, String> {
     let (name, value) = input
         .split_once(':')
         .ok_or_else(|| "header must be in NAME:VALUE format".to_string())?;
@@ -1204,12 +1200,8 @@ mod tests {
         async fn get_extended_agent_card(
             &self,
             _params: &HandlerServiceParams,
-            req: GetExtendedAgentCardRequest,
+            _req: GetExtendedAgentCardRequest,
         ) -> Result<AgentCard, A2AError> {
-            if req.tenant.as_deref() == Some("error") {
-                return Err(A2AError::unsupported_operation("extended card denied"));
-            }
-
             Ok(self.extended_card.clone())
         }
     }
@@ -1306,23 +1298,19 @@ mod tests {
 
     #[test]
     fn test_build_send_message_request_populates_optional_fields() {
-        let request = build_send_message_request(
-            &SendCommand {
-                agent_ref: "http://localhost:3000".to_string(),
-                text: "hello".to_string(),
-                context_id: Some("ctx-1".to_string()),
-                task_id: Some("task-1".to_string()),
-                history_length: Some(4),
-                accepted_output_modes: vec!["text/plain".to_string()],
-                return_immediately: true,
-            },
-            Some("tenant-1".to_string()),
-        );
+        let request = build_send_message_request(&SendCommand {
+            agent_ref: "http://localhost:3000".to_string(),
+            text: "hello".to_string(),
+            context_id: Some("ctx-1".to_string()),
+            task_id: Some("task-1".to_string()),
+            history_length: Some(4),
+            accepted_output_modes: vec!["text/plain".to_string()],
+            return_immediately: true,
+        });
 
         assert_eq!(request.message.text(), Some("hello"));
         assert_eq!(request.message.context_id.as_deref(), Some("ctx-1"));
         assert_eq!(request.message.task_id.as_deref(), Some("task-1"));
-        assert_eq!(request.tenant.as_deref(), Some("tenant-1"));
         assert_eq!(
             request
                 .configuration
@@ -1341,22 +1329,18 @@ mod tests {
 
     #[test]
     fn test_build_send_message_request_without_optional_fields() {
-        let request = build_send_message_request(
-            &SendCommand {
-                agent_ref: "http://localhost:3000".to_string(),
-                text: "hello".to_string(),
-                context_id: None,
-                task_id: None,
-                history_length: None,
-                accepted_output_modes: Vec::new(),
-                return_immediately: false,
-            },
-            None,
-        );
+        let request = build_send_message_request(&SendCommand {
+            agent_ref: "http://localhost:3000".to_string(),
+            text: "hello".to_string(),
+            context_id: None,
+            task_id: None,
+            history_length: None,
+            accepted_output_modes: Vec::new(),
+            return_immediately: false,
+        });
 
         assert_eq!(request.message.text(), Some("hello"));
         assert!(request.configuration.is_none());
-        assert!(request.tenant.is_none());
     }
 
     #[test]
@@ -1799,14 +1783,6 @@ mod tests {
     async fn test_run_surfaces_errors_in_lib_tests() {
         let server = RunTestServer::spawn().await;
         let base_url = &server.base_url;
-
-        let err = run(parse_cli(&["discover", base_url, "--extended", "--tenant", "error"]))
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            CliError::A2A(error) if error.code == a2a::error_code::UNSUPPORTED_OPERATION
-        ));
 
         let err = run(parse_cli(&["send", base_url, "send-error"]))
             .await

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -354,12 +354,14 @@ pub enum CliError {
     Config(#[from] config::ConfigError),
 }
 
-pub async fn run(mut cli: Cli) -> Result<(), CliError> {
+pub async fn run(cli: Cli) -> Result<(), CliError> {
     #[cfg(not(test))]
-    {
+    let cli = {
+        let mut cli = cli;
         let (cfg, cfg_path) = config::load_config()?;
         config::apply_config(&mut cli, &cfg, &cfg_path)?;
-    }
+        cli
+    };
     let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -16,11 +16,11 @@ use thiserror::Error;
 #[derive(Debug, Clone, Parser, PartialEq, Eq)]
 #[command(name = "a2a", version, about = "A2A client CLI")]
 pub struct Cli {
-    /// Enabled transports in preference order (first = most preferred).
-    /// Repeat the flag to enable multiple transports, e.g. --transport jsonrpc --transport http-json.
-    /// Only transports listed here will be used; the order overrides the server's preference.
-    #[arg(long = "transport", global = true, value_enum)]
-    pub transports: Vec<Transport>,
+    /// Enabled protocol bindings in preference order (first = most preferred).
+    /// Repeat the flag to enable multiple bindings, e.g. --enabled-binding jsonrpc --enabled-binding http-json.
+    /// Only bindings listed here will be used; the order overrides the server's preference.
+    #[arg(long = "enabled-binding", global = true, value_enum)]
+    pub enabled_bindings: Vec<Binding>,
 
     /// Bearer token attached to the agent-card fetch and client calls.
     #[arg(long, global = true, env = "A2A_BEARER_TOKEN")]
@@ -291,21 +291,21 @@ pub struct HeaderArg {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum Transport {
+pub enum Binding {
     Jsonrpc,
     HttpJson,
 }
 
-impl Transport {
+impl Binding {
     fn protocol(self) -> &'static str {
         match self {
-            Transport::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
-            Transport::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+            Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
+            Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
         }
     }
 }
 
-const DEFAULT_TRANSPORTS: &[Transport] = &[Transport::Jsonrpc, Transport::HttpJson];
+const DEFAULT_BINDINGS: &[Binding] = &[Binding::Jsonrpc, Binding::HttpJson];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum TaskStateArg {
@@ -609,15 +609,15 @@ async fn resolve_client(
 ) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
     let card = resolve_agent_card(agent_ref, cli).await?;
 
-    let effective_transports = if cli.transports.is_empty() {
-        DEFAULT_TRANSPORTS.to_vec()
+    let effective_bindings = if cli.enabled_bindings.is_empty() {
+        DEFAULT_BINDINGS.to_vec()
     } else {
-        cli.transports.clone()
+        cli.enabled_bindings.clone()
     };
 
-    let preferred: Vec<String> = effective_transports
+    let preferred: Vec<String> = effective_bindings
         .iter()
-        .map(|t| t.protocol().to_string())
+        .map(|b| b.protocol().to_string())
         .collect();
 
     let mut builder = A2AClientFactory::builder().preferred_bindings(preferred);
@@ -1346,7 +1346,7 @@ mod tests {
     #[test]
     fn test_cli_parse_send_command() {
         let cli = parse_cli(&[
-            "--transport",
+            "--enabled-binding",
             "jsonrpc",
             "--header",
             "X-Test:123",
@@ -1357,7 +1357,7 @@ mod tests {
             "2",
         ]);
 
-        assert_eq!(cli.transports, vec![crate::Transport::Jsonrpc]);
+        assert_eq!(cli.enabled_bindings, vec![crate::Binding::Jsonrpc]);
         assert_eq!(cli.headers.len(), 1);
         assert!(matches!(cli.command, Command::Send(_)));
     }
@@ -1461,9 +1461,9 @@ mod tests {
     }
 
     #[test]
-    fn test_transport_protocols() {
-        assert_eq!(crate::Transport::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
-        assert_eq!(crate::Transport::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+    fn test_binding_protocols() {
+        assert_eq!(crate::Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
+        assert_eq!(crate::Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
     }
 
     #[test]
@@ -1678,7 +1678,7 @@ mod tests {
             .await
             .unwrap();
         run(parse_cli(&[
-            "--transport",
+            "--enabled-binding",
             "jsonrpc",
             "--bearer-token",
             "secret",

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -367,7 +367,7 @@ pub async fn run(mut cli: Cli) -> Result<(), CliError> {
             if command.extended {
                 let client = resolve_client(&command.agent_ref, &cli).await?;
                 let result = client
-                    .get_extended_agent_card(&GetExtendedAgentCardRequest { tenant: None })
+                    .get_extended_agent_card(GetExtendedAgentCardRequest { tenant: None })
                     .await;
                 let card = finish_client_call(client, result).await?;
                 print_json(&card, compact)?;
@@ -379,14 +379,14 @@ pub async fn run(mut cli: Cli) -> Result<(), CliError> {
         Command::Send(command) => {
             let request = build_send_message_request(command);
             let client = resolve_client(&command.agent_ref, &cli).await?;
-            let result = client.send_message(&request).await;
+            let result = client.send_message(request).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
         }
         Command::Stream(command) => {
             let client = resolve_client(&command.agent_ref, &cli).await?;
             let request = build_stream_message_request(command);
-            let stream = client.send_streaming_message(&request).await?;
+            let stream = client.send_streaming_message(request).await?;
             consume_stream(client, stream, compact).await?;
         }
         Command::Task { command } => {
@@ -464,7 +464,7 @@ async fn run_task_command(
         TaskCommand::Get(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .get_task(&GetTaskRequest {
+                .get_task(GetTaskRequest {
                     id: command.id.clone(),
                     history_length: command.history_length,
                     tenant: None,
@@ -476,7 +476,7 @@ async fn run_task_command(
         TaskCommand::List(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .list_tasks(&ListTasksRequest {
+                .list_tasks(ListTasksRequest {
                     context_id: command.context_id.clone(),
                     status: command.status.map(TaskState::from),
                     page_size: command.page_size,
@@ -493,7 +493,7 @@ async fn run_task_command(
         TaskCommand::Cancel(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .cancel_task(&CancelTaskRequest {
+                .cancel_task(CancelTaskRequest {
                     id: command.id.clone(),
                     metadata: None,
                     tenant: None,
@@ -505,7 +505,7 @@ async fn run_task_command(
         TaskCommand::Subscribe(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let stream = client
-                .subscribe_to_task(&SubscribeToTaskRequest {
+                .subscribe_to_task(SubscribeToTaskRequest {
                     id: command.id.clone(),
                     tenant: None,
                 })
@@ -553,14 +553,14 @@ async fn run_push_config_command(
             let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
-            let result = client.create_push_config(&config).await;
+            let result = client.create_push_config(config).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
         }
         PushConfigCommand::Get(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .get_push_config(&GetTaskPushNotificationConfigRequest {
+                .get_push_config(GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
                     tenant: None,
@@ -572,7 +572,7 @@ async fn run_push_config_command(
         PushConfigCommand::List(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .list_push_configs(&ListTaskPushNotificationConfigsRequest {
+                .list_push_configs(ListTaskPushNotificationConfigsRequest {
                     task_id: command.task_id.clone(),
                     page_size: command.page_size,
                     page_token: command.page_token.clone(),
@@ -585,7 +585,7 @@ async fn run_push_config_command(
         PushConfigCommand::Delete(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
+                .delete_push_config(DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
                     tenant: None,
@@ -657,7 +657,7 @@ async fn resolve_agent_card(agent_ref: &str, cli: &Cli) -> Result<AgentCard, Cli
             reason: e.to_string(),
         })
     } else {
-        let json = std::fs::read_to_string(agent_ref)?;
+        let json = tokio::fs::read_to_string(agent_ref).await?;
         serde_json::from_str(&json).map_err(|e| CliError::InvalidAgentCard {
             reason: e.to_string(),
         })

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -355,8 +355,11 @@ pub enum CliError {
 }
 
 pub async fn run(mut cli: Cli) -> Result<(), CliError> {
-    let (cfg, cfg_path) = config::load_config()?;
-    config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    #[cfg(not(test))]
+    {
+        let (cfg, cfg_path) = config::load_config()?;
+        config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    }
     let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -367,12 +367,8 @@ impl RequestHandler for TestHandler {
     async fn get_extended_agent_card(
         &self,
         _params: &ServiceParams,
-        req: GetExtendedAgentCardRequest,
+        _req: GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
-        if req.tenant.as_deref() == Some("error") {
-            return Err(A2AError::unsupported_operation("extended card denied"));
-        }
-
         Ok(self.extended_card.clone())
     }
 }
@@ -585,8 +581,6 @@ async fn push_config_crud_commands_work() {
     let create = run_cli_success(&[
         "-o",
         "json",
-        "--tenant",
-        "tenant-1",
         "push-config",
         "create",
         base_url,
@@ -604,7 +598,6 @@ async fn push_config_crud_commands_work() {
     let create_json: Value = serde_json::from_str(create.trim()).unwrap();
     assert_eq!(create_json["taskId"], "task-1");
     assert_eq!(create_json["id"], "cfg-1");
-    assert_eq!(create_json["tenant"], "tenant-1");
 
     let get = run_cli_success(&[
         "-o",
@@ -660,15 +653,6 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("http request failed:"));
 
-    let (_stdout, stderr) = run_cli_failure(&[
-        "discover",
-        base_url,
-        "--extended",
-        "--tenant",
-        "error",
-    ]);
-    assert!(stderr.contains("a2a error -32004: extended card denied"));
-
     let (_stdout, stderr) = run_cli_failure(&["send", base_url, "send-error"]);
     assert!(stderr.contains("a2a error -32600: send failed"));
 
@@ -721,4 +705,27 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
         "secret",
     ]);
     assert!(stderr.contains("invalid input: --auth-credentials requires --auth-scheme"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_file_sets_output_format() {
+    let server = TestServer::spawn().await;
+    let base_url = &server.base_url;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".a2a.yaml"), "output: json\n").unwrap();
+
+    let output = StdCommand::cargo_bin("a2a")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["discover", base_url])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    // compact JSON (output: json) is a single line; pretty-printed JSON spans multiple lines
+    assert_eq!(stdout.trim().lines().count(), 1);
 }

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -478,7 +478,7 @@ async fn card_and_extended_card_commands_work() {
     assert_eq!(headers[0].1.as_deref(), Some("abc"));
 
     let compact = run_cli_success(&[
-        "--transport",
+        "--enabled-binding",
         "http-json",
         "-o",
         "json",

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -428,17 +428,15 @@ fn make_task(task_id: &str, context_id: &str, state: TaskState, text: &str) -> T
     }
 }
 
-fn run_cli_success(server: &TestServer, args: &[&str]) -> String {
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
-    command.args(["--base-url", server.base_url.as_str()]);
+fn run_cli_success(args: &[&str]) -> String {
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     command.args(args);
     let output = command.assert().success().get_output().stdout.clone();
     String::from_utf8(output).unwrap()
 }
 
-fn run_cli_failure(server: &TestServer, args: &[&str]) -> (String, String) {
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
-    command.args(["--base-url", server.base_url.as_str()]);
+fn run_cli_failure(args: &[&str]) -> (String, String) {
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     command.args(args);
     let output = command.assert().failure().get_output().clone();
     (
@@ -465,17 +463,16 @@ async fn unused_base_url() -> String {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn card_and_extended_card_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let stdout = run_cli_success(
-        &server,
-        &[
-            "--bearer-token",
-            "secret",
-            "--header",
-            "X-Test: abc",
-            "card",
-        ],
-    );
+    let stdout = run_cli_success(&[
+        "--bearer-token",
+        "secret",
+        "--header",
+        "X-Test: abc",
+        "discover",
+        base_url,
+    ]);
     let card: Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(card["name"], "Fixture Agent");
 
@@ -484,10 +481,15 @@ async fn card_and_extended_card_commands_work() {
     assert_eq!(headers[0].0.as_deref(), Some("Bearer secret"));
     assert_eq!(headers[0].1.as_deref(), Some("abc"));
 
-    let compact = run_cli_success(
-        &server,
-        &["--binding", "http-json", "--compact", "extended-card"],
-    );
+    let compact = run_cli_success(&[
+        "--transport",
+        "http-json",
+        "-o",
+        "json",
+        "discover",
+        base_url,
+        "--extended",
+    ]);
     assert!(!compact.trim_end().contains('\n'));
     let card: Value = serde_json::from_str(compact.trim()).unwrap();
     assert_eq!(card["name"], "Fixture Agent (extended)");
@@ -496,25 +498,24 @@ async fn card_and_extended_card_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn send_task_list_and_cancel_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let send = run_cli_success(
-        &server,
-        &[
-            "--bearer-token",
-            "secret",
-            "--header",
-            "X-Trace: 123",
-            "send",
-            "hello from cli",
-            "--task-id",
-            "task-send",
-            "--context-id",
-            "ctx-send",
-            "--accept-output",
-            "text/plain",
-            "--return-immediately",
-        ],
-    );
+    let send = run_cli_success(&[
+        "--bearer-token",
+        "secret",
+        "--header",
+        "X-Trace: 123",
+        "send",
+        base_url,
+        "hello from cli",
+        "--task-id",
+        "task-send",
+        "--context-id",
+        "ctx-send",
+        "--accept-output",
+        "text/plain",
+        "--return-immediately",
+    ]);
     let send_json: Value = serde_json::from_str(&send).unwrap();
     assert_eq!(send_json["task"]["id"], "task-send");
     assert_eq!(
@@ -522,25 +523,25 @@ async fn send_task_list_and_cancel_commands_work() {
         "Echo: hello from cli"
     );
 
-    let get_task = run_cli_success(&server, &["get-task", "task-send", "--history-length", "1"]);
+    let get_task = run_cli_success(&["task", "get", base_url, "task-send", "--history-length", "1"]);
     let task_json: Value = serde_json::from_str(&get_task).unwrap();
     assert_eq!(task_json["id"], "task-send");
 
-    let list = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "list-tasks",
-            "--context-id",
-            "ctx-send",
-            "--status",
-            "completed",
-        ],
-    );
+    let list = run_cli_success(&[
+        "-o",
+        "json",
+        "task",
+        "list",
+        base_url,
+        "--context-id",
+        "ctx-send",
+        "--status",
+        "completed",
+    ]);
     let list_json: Value = serde_json::from_str(list.trim()).unwrap();
     assert_eq!(list_json["tasks"].as_array().unwrap().len(), 1);
 
-    let cancel = run_cli_success(&server, &["cancel-task", "task-send"]);
+    let cancel = run_cli_success(&["task", "cancel", base_url, "task-send"]);
     let cancel_json: Value = serde_json::from_str(&cancel).unwrap();
     assert_eq!(cancel_json["status"]["state"], "TASK_STATE_CANCELED");
 }
@@ -548,19 +549,19 @@ async fn send_task_list_and_cancel_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stream_and_subscribe_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let stream_output = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "stream",
-            "streaming request",
-            "--task-id",
-            "task-stream",
-            "--context-id",
-            "ctx-stream",
-        ],
-    );
+    let stream_output = run_cli_success(&[
+        "-o",
+        "json",
+        "stream",
+        base_url,
+        "streaming request",
+        "--task-id",
+        "task-stream",
+        "--context-id",
+        "ctx-stream",
+    ]);
     let stream_events = parse_json_lines(&stream_output);
     assert_eq!(stream_events.len(), 2);
     assert_eq!(
@@ -569,7 +570,8 @@ async fn stream_and_subscribe_commands_work() {
     );
     assert_eq!(stream_events[1]["task"]["id"], "task-stream");
 
-    let subscribe_output = run_cli_success(&server, &["--compact", "subscribe", "task-stream"]);
+    let subscribe_output =
+        run_cli_success(&["-o", "json", "task", "subscribe", base_url, "task-stream"]);
     let subscribe_events = parse_json_lines(&subscribe_output);
     assert_eq!(subscribe_events.len(), 2);
     assert_eq!(subscribe_events[1]["task"]["id"], "task-stream");
@@ -578,57 +580,66 @@ async fn stream_and_subscribe_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn push_config_crud_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let create = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "--tenant",
-            "tenant-1",
-            "push-config",
-            "create",
-            "task-1",
-            "https://example.com/callback",
-            "--config-id",
-            "cfg-1",
-            "--token",
-            "tok-1",
-            "--auth-scheme",
-            "Bearer",
-            "--auth-credentials",
-            "secret",
-        ],
-    );
+    let create = run_cli_success(&[
+        "-o",
+        "json",
+        "--tenant",
+        "tenant-1",
+        "push-config",
+        "create",
+        base_url,
+        "task-1",
+        "https://example.com/callback",
+        "--config-id",
+        "cfg-1",
+        "--token",
+        "tok-1",
+        "--auth-scheme",
+        "Bearer",
+        "--auth-credentials",
+        "secret",
+    ]);
     let create_json: Value = serde_json::from_str(create.trim()).unwrap();
     assert_eq!(create_json["taskId"], "task-1");
     assert_eq!(create_json["id"], "cfg-1");
     assert_eq!(create_json["tenant"], "tenant-1");
 
-    let get = run_cli_success(
-        &server,
-        &["--compact", "push-config", "get", "task-1", "cfg-1"],
-    );
+    let get = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "get",
+        base_url,
+        "task-1",
+        "cfg-1",
+    ]);
     let get_json: Value = serde_json::from_str(get.trim()).unwrap();
     assert_eq!(get_json["authentication"]["scheme"], "Bearer");
 
-    let list = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "push-config",
-            "list",
-            "task-1",
-            "--page-size",
-            "10",
-        ],
-    );
+    let list = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "list",
+        base_url,
+        "task-1",
+        "--page-size",
+        "10",
+    ]);
     let list_json: Value = serde_json::from_str(list.trim()).unwrap();
     assert_eq!(list_json["configs"].as_array().unwrap().len(), 1);
 
-    let delete = run_cli_success(
-        &server,
-        &["--compact", "push-config", "delete", "task-1", "cfg-1"],
-    );
+    let delete = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "delete",
+        base_url,
+        "task-1",
+        "cfg-1",
+    ]);
     let delete_json: Value = serde_json::from_str(delete.trim()).unwrap();
     assert_eq!(delete_json["deleted"], true);
 }
@@ -636,11 +647,12 @@ async fn push_config_crud_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn binary_reports_a2a_and_non_a2a_errors() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let base_url = unused_base_url().await;
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
+    let unreachable_url = unused_base_url().await;
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     let output = command
-        .args(["--base-url", base_url.as_str(), "card"])
+        .args(["discover", unreachable_url.as_str()])
         .assert()
         .failure()
         .get_output()
@@ -648,60 +660,65 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("http request failed:"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["extended-card", "--tenant", "error"]);
+    let (_stdout, stderr) = run_cli_failure(&[
+        "discover",
+        base_url,
+        "--extended",
+        "--tenant",
+        "error",
+    ]);
     assert!(stderr.contains("a2a error -32004: extended card denied"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["send", "send-error"]);
+    let (_stdout, stderr) = run_cli_failure(&["send", base_url, "send-error"]);
     assert!(stderr.contains("a2a error -32600: send failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["list-tasks", "--context-id", "error"]);
+    let (_stdout, stderr) =
+        run_cli_failure(&["task", "list", base_url, "--context-id", "error"]);
     assert!(stderr.contains("a2a error -32602: list failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["get-task", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "get", base_url, "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["cancel-task", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "cancel", base_url, "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["subscribe", "stream-error"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "subscribe", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["--compact", "stream", "stream-error"]);
+    let (_stdout, stderr) =
+        run_cli_failure(&["-o", "json", "stream", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
-    let (_stdout, stderr) = run_cli_failure(
-        &server,
-        &[
-            "push-config",
-            "create",
-            "missing",
-            "https://example.com/callback",
-            "--config-id",
-            "cfg-missing",
-        ],
-    );
-    assert!(stderr.contains("a2a error -32001: task not found: missing"));
-
-    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "get", "task-1", "missing"]);
-    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
-
-    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "list", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&[
+        "push-config",
+        "create",
+        base_url,
+        "missing",
+        "https://example.com/callback",
+        "--config-id",
+        "cfg-missing",
+    ]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
     let (_stdout, stderr) =
-        run_cli_failure(&server, &["push-config", "delete", "task-1", "missing"]);
+        run_cli_failure(&["push-config", "get", base_url, "task-1", "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: task-1"));
 
-    let (_stdout, stderr) = run_cli_failure(
-        &server,
-        &[
-            "push-config",
-            "create",
-            "task-1",
-            "https://example.com/callback",
-            "--auth-credentials",
-            "secret",
-        ],
-    );
+    let (_stdout, stderr) = run_cli_failure(&["push-config", "list", base_url, "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) =
+        run_cli_failure(&["push-config", "delete", base_url, "task-1", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
+
+    let (_stdout, stderr) = run_cli_failure(&[
+        "push-config",
+        "create",
+        base_url,
+        "task-1",
+        "https://example.com/callback",
+        "--auth-credentials",
+        "secret",
+    ]);
     assert!(stderr.contains("invalid input: --auth-credentials requires --auth-scheme"));
 }


### PR DESCRIPTION
## Summary

Redesigns the `a2a` CLI and the `a2a-client` library per the proposal in issue #1929.

### Changes

**`--transport` flag (replaces `--binding`)**
- `--transport` is now a repeatable, ordered flag (e.g. `--transport jsonrpc --transport http-json`)
- Default when omitted: `[jsonrpc, http-json]`
- SlimRPC must be explicitly listed even when compiled in with the `slimrpc` feature
- Removes the old `--binding` single-value flag

**`.a2a.yaml` config file**
- New hierarchical config file: walks from CWD up to (inclusive) the home directory looking for `.a2a.yaml`
- Supports: `transports`, `bearer_token`, `headers`, `output`
- CLI flags always take precedence; `headers` are additive (config first, then flags)
- Config discovery logic is in `a2acli/src/config.rs` with unit tests using `tempfile`

**Tenant auto-injection from `AgentInterface`**
- Removed `--tenant` CLI flag and any `tenant` field from the config file
- `A2AClient` now stores `tenant: Option<String>` (set via `.with_tenant()` builder)
- All 11 request-forwarding methods unconditionally override the request's `tenant` field with the client's stored value — callers cannot set tenant per-request
- `A2AClientFactory::create_from_card` chains `.with_tenant(iface.tenant.clone())` so the tenant from the selected `AgentInterface` is automatically applied to every request

**Output format**
- `--output` / `-o` is now `Option<OutputFormat>` (no clap default); config file fills it in if absent; final fallback is `pretty`
- Enables the config file to control output format without conflicting with clap's default

## Files changed

| File | Change |
|------|--------|
| `a2acli/src/lib.rs` | CLI struct, command parsing, request builders, output logic |
| `a2acli/src/config.rs` | New: config file discovery, loading, and merging |
| `a2acli/Cargo.toml` | Add `serde_yaml`, `tempfile` dev-dep |
| `Cargo.toml` | Add `serde_yaml = "0.9"` to workspace deps |
| `a2a-client/src/client.rs` | `tenant` field, `with_tenant()`, patching in all 11 methods |
| `a2a-client/src/factory.rs` | Chain `.with_tenant(iface.tenant.clone())` |
| `a2acli/tests/e2e.rs` | Update tests: `--transport`, remove `--tenant`, add config-file output test |