### PR TITLE
feat(slimrpc): add SlimRPC transport support to a2acli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,8 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "a2a-client-lf",
  "a2a-lf",
  "a2a-server-lf",
+ "a2a-slimrpc",
  "assert_cmd",
  "async-trait",
  "axum",
@@ -19,8 +20,9 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -76,7 +78,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -146,9 +148,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9acd36127fe01f3175795bd46e0f0ced9ced4a6dfaf56a2bdc3e08c4c09fd9"
+version = "0.13.0"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
@@ -172,14 +173,14 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
  "spiffe",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower",
@@ -194,9 +195,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c230d21b7ff14b039ce0eef5fd9b5912d819fe6c0b21c653348c69ac400c13"
+version = "0.12.4"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -229,7 +229,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-retry",
  "tokio-rustls",
@@ -250,9 +250,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300285f29418c4860d1965bf4bb24ad091e9fc64ea0ceec015a75be7f03abe"
+version = "0.11.3"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -271,7 +270,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -283,9 +282,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb174b04bc4c03c1a36b9febedac279a051399a52e090bd96236a162cb277be2"
+version = "0.16.5"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -310,7 +308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -327,9 +325,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432e81905ee835155199bc8c3b82378a9fa7e98b49a890df539efae43277c115"
+version = "0.2.4"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -343,23 +340,22 @@ dependencies = [
  "mls-rs-crypto-awslc",
  "mls-rs-crypto-webcrypto",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2245bddf34d2adb4b88ed3ae7f519234e8814cb77172befcbb361afd5442b1"
+version = "0.3.3"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -369,9 +365,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2f6d7daa77f8828d35b0733a92675022b92ab3c1fb2737b31eed2ec10a06ac"
+version = "2.0.0-alpha.5"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -384,7 +379,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "parking_lot",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -393,9 +388,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60eeefbe422463f5bf4fb5762f2e635ec92e57fe9550609fb006edeeb272557"
+version = "0.11.4"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -405,11 +399,14 @@ dependencies = [
  "agntcy-slim-session",
  "agntcy-slim-version",
  "async-trait",
+ "dirs",
  "display-error-chain",
  "futures",
+ "humantime-serde",
  "parking_lot",
  "serde",
- "thiserror 2.0.18",
+ "serde_yaml",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -419,9 +416,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3436a6202933b26de20a965c3d53d18b5201f7ef589a7023cee8697fc7f946d5"
+version = "0.5.4"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -436,11 +432,11 @@ dependencies = [
  "maybe-async",
  "parking_lot",
  "prost",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tokio_with_wasm",
@@ -452,9 +448,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289a5c0fcc673c1c7892a943900a4e2b12b57fc21584e0c655282d28e5b5db8f"
+version = "0.1.13"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -463,9 +458,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabfc55cd2966cb3ef605ca1dae3246cdf94ff7aa3b58ddcdc18403930ae5609"
+version = "0.4.6"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -478,7 +472,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -488,9 +482,8 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa135cef8d8920ceb361b1c27f23636a6b3226fa3173726931339ddd18a4eae"
+version = "2.0.0-alpha.5"
+source = "git+https://github.com/agntcy/slim?branch=feat%2Fhierarchical-slim-config-loading#f39c40bde81a876353ec223aa29d6f18faa52432"
 
 [[package]]
 name = "aho-corasick"
@@ -568,24 +561,24 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -593,7 +586,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -605,7 +598,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -617,7 +610,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -632,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -664,18 +657,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -692,20 +685,20 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.15"
+version = "0.13.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
+checksum = "37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5"
 dependencies = [
  "bindgen",
  "cc",
@@ -802,7 +795,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -857,7 +850,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -867,21 +860,24 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -894,37 +890,37 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -944,9 +940,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -961,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -986,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -996,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1008,14 +1004,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1113,9 +1109,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1123,18 +1119,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-bigint"
@@ -1150,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1181,7 +1177,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1205,7 +1201,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1216,14 +1212,14 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -1295,7 +1291,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1303,9 +1299,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "difflib"
@@ -1326,6 +1319,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "display-error-chain"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,13 +1347,13 @@ checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1412,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1488,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastwebsockets"
@@ -1504,7 +1518,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.7",
  "sha1",
  "simdutf8",
  "thiserror 1.0.69",
@@ -1584,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1609,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1624,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1634,15 +1648,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1651,44 +1665,44 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1703,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1741,16 +1755,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1802,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1830,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1904,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1914,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1924,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1948,10 +1962,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "humantime"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1971,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -2145,12 +2175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2184,27 +2208,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2214,16 +2236,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2267,7 +2279,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2282,7 +2294,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2301,36 +2313,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2341,13 +2352,14 @@ dependencies = [
  "serde_json",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2355,11 +2367,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -2370,16 +2382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2389,6 +2395,15 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2414,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2424,7 +2439,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2450,20 +2465,20 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -2479,9 +2494,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2513,7 +2528,7 @@ dependencies = [
  "serde",
  "spin",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -2526,7 +2541,7 @@ checksum = "45bd834f164dc06c1fed805540ae307a460b7ed7c2769a35a376f1de577a0dc1"
 dependencies = [
  "itertools 0.14.0",
  "mls-rs-codec-derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
 ]
 
@@ -2539,7 +2554,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2553,7 +2568,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-codec",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -2572,7 +2587,7 @@ dependencies = [
  "mls-rs-crypto-hpke",
  "mls-rs-crypto-traits",
  "mls-rs-identity-x509",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -2587,7 +2602,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "mls-rs-crypto-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -2619,7 +2634,7 @@ dependencies = [
  "mls-rs-crypto-traits",
  "serde",
  "serde-wasm-bindgen",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2635,7 +2650,7 @@ dependencies = [
  "async-trait",
  "maybe-async",
  "mls-rs-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
 ]
 
@@ -2678,7 +2693,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2696,7 +2711,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2710,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2720,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2762,7 +2777,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2795,15 +2810,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2816,7 +2830,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2827,9 +2841,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2847,7 +2861,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2877,7 +2891,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.12.28",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tracing",
@@ -2924,11 +2938,17 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -3031,22 +3051,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3073,18 +3093,18 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3147,7 +3167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3161,18 +3181,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3180,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -3195,28 +3215,28 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -3287,11 +3307,11 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -3307,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3319,7 +3339,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3327,21 +3347,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3349,23 +3370,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3384,9 +3405,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3395,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3410,7 +3431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3459,6 +3480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -3498,34 +3528,45 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3535,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3546,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3664,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3692,7 +3733,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3701,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3716,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3737,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3774,9 +3815,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3786,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3836,7 +3877,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3865,7 +3906,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3890,9 +3931,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3911,22 +3952,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3937,14 +3978,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3991,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4027,6 +4068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4070,7 +4117,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -4082,15 +4129,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4113,7 +4160,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-util",
@@ -4127,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "portable-atomic",
 ]
@@ -4164,9 +4211,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4190,7 +4248,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4199,7 +4257,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4221,7 +4279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4244,11 +4302,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4259,37 +4317,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4299,15 +4356,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4325,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4340,9 +4397,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -4357,13 +4414,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4442,14 +4499,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -4476,21 +4533,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4499,16 +4556,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -4553,22 +4610,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4603,7 +4660,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4679,7 +4736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4703,7 +4760,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4714,18 +4771,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -4738,12 +4795,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4796,11 +4847,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4859,27 +4910,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4890,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4900,9 +4942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4910,46 +4952,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4966,22 +4986,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4999,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5036,7 +5044,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5047,7 +5055,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5087,6 +5095,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5110,6 +5127,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5147,6 +5179,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5159,6 +5197,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5168,6 +5212,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5195,6 +5245,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5204,6 +5260,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5219,6 +5281,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5228,6 +5296,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5266,91 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -5382,24 +5374,25 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5414,35 +5407,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5455,28 +5448,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5509,11 +5502,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,14 @@ prost = "0.14"
 prost-types = "0.14"
 pbjson-build = "0.9"
 protoc-bin-vendored = "3"
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.3" }
-slim_config = { package = "agntcy-slim-config", version = "0.12.1" }
-slim_service = { package = "agntcy-slim-service", version = "0.11.1", features = [
+slim_rpc = { package = "agntcy-slim-rpc", git = "https://github.com/agntcy/slim", branch = "feat/hierarchical-slim-config-loading" }
+slim_config = { package = "agntcy-slim-config", git = "https://github.com/agntcy/slim", branch = "feat/hierarchical-slim-config-loading" }
+slim_service = { package = "agntcy-slim-service", git = "https://github.com/agntcy/slim", branch = "feat/hierarchical-slim-config-loading", features = [
     "session",
+    "slim-config",
 ] }
-slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.2" }
-slim_auth = { package = "agntcy-slim-auth", version = "0.12.0" }
+slim_datapath = { package = "agntcy-slim-datapath", git = "https://github.com/agntcy/slim", branch = "feat/hierarchical-slim-config-loading" }
+slim_auth = { package = "agntcy-slim-auth", git = "https://github.com/agntcy/slim", branch = "feat/hierarchical-slim-config-loading" }
 
 # Utilities
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,4 @@ semver = "1"
 tracing = "0.1"
 auto_impl = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.2.0"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 pbjson = "0.9"
 pbjson-types = "0.9"
 

--- a/README.md
+++ b/README.md
@@ -142,18 +142,30 @@ HTTP+JSON, prints responses as JSON, and manages task push notification
 configs.
 
 ```sh
-cargo run --bin a2acli -- card
-cargo run --bin a2acli -- send "hello from rust"
-cargo run --bin a2acli -- stream "hello from rust"
-cargo run --bin a2acli -- list-tasks
-cargo run --bin a2acli -- push-config list task-123
+# Inspect an agent card
+a2a discover http://localhost:3000
+
+# Send a one-shot message
+a2a send http://localhost:3000 "hello from rust"
+
+# Send a streaming message
+a2a stream http://localhost:3000 "hello from rust"
+
+# List tasks
+a2a task list http://localhost:3000
+
+# Manage push notification configs
+a2a push-config list http://localhost:3000 task-123
 ```
 
-By default the CLI targets `http://localhost:3000`, which matches the bundled
-hello world server. Override the target with `--base-url https://host` for any
-compatible A2A server, use `--binding jsonrpc` or `--binding http-json` to pin
+Each command takes an agent reference as its first argument: a base URL
+(`http://host` → card fetched from `/.well-known/agent-card.json`), a direct
+URL to a card JSON file (`https://host/path/agent.json`), or a local file path.
+Use `--enabled-binding jsonrpc` or `--enabled-binding http-json` to pin
 transport selection, and pass `--bearer-token` or repeated `--header Name:Value`
 arguments when the server requires authentication.
+
+See [`a2acli/README.md`](a2acli/README.md) for the full command reference.
 
 ## Depending On The Workspace
 

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -14,6 +14,7 @@ pub struct A2AClient<T: Transport> {
     transport: T,
     interceptors: Vec<Arc<dyn CallInterceptor>>,
     default_params: ServiceParams,
+    tenant: Option<String>,
 }
 
 impl<T: Transport> A2AClient<T> {
@@ -24,11 +25,17 @@ impl<T: Transport> A2AClient<T> {
             transport,
             interceptors: Vec::new(),
             default_params,
+            tenant: None,
         }
     }
 
     pub fn with_interceptors(mut self, interceptors: Vec<Arc<dyn CallInterceptor>>) -> Self {
         self.interceptors = interceptors;
+        self
+    }
+
+    pub fn with_tenant(mut self, tenant: Option<String>) -> Self {
+        self.tenant = tenant;
         self
     }
 
@@ -75,7 +82,11 @@ impl<T: Transport> A2AClient<T> {
         req: &SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
         let params = self.apply_before(methods::SEND_MESSAGE).await?;
-        let result = self.transport.send_message(&params, req).await;
+        let patched = SendMessageRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.send_message(&params, &patched).await;
         self.finish_call(methods::SEND_MESSAGE, result).await
     }
 
@@ -84,26 +95,45 @@ impl<T: Transport> A2AClient<T> {
         req: &SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SEND_STREAMING_MESSAGE).await?;
-        let result = self.transport.send_streaming_message(&params, req).await;
+        let patched = SendMessageRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self
+            .transport
+            .send_streaming_message(&params, &patched)
+            .await;
         self.finish_call(methods::SEND_STREAMING_MESSAGE, result)
             .await
     }
 
     pub async fn get_task(&self, req: &GetTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::GET_TASK).await?;
-        let result = self.transport.get_task(&params, req).await;
+        let patched = GetTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.get_task(&params, &patched).await;
         self.finish_call(methods::GET_TASK, result).await
     }
 
     pub async fn list_tasks(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
         let params = self.apply_before(methods::LIST_TASKS).await?;
-        let result = self.transport.list_tasks(&params, req).await;
+        let patched = ListTasksRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.list_tasks(&params, &patched).await;
         self.finish_call(methods::LIST_TASKS, result).await
     }
 
     pub async fn cancel_task(&self, req: &CancelTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::CANCEL_TASK).await?;
-        let result = self.transport.cancel_task(&params, req).await;
+        let patched = CancelTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.cancel_task(&params, &patched).await;
         self.finish_call(methods::CANCEL_TASK, result).await
     }
 
@@ -112,7 +142,11 @@ impl<T: Transport> A2AClient<T> {
         req: &SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SUBSCRIBE_TO_TASK).await?;
-        let result = self.transport.subscribe_to_task(&params, req).await;
+        let patched = SubscribeToTaskRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.subscribe_to_task(&params, &patched).await;
         self.finish_call(methods::SUBSCRIBE_TO_TASK, result).await
     }
 
@@ -121,7 +155,11 @@ impl<T: Transport> A2AClient<T> {
         req: &TaskPushNotificationConfig,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::CREATE_PUSH_CONFIG).await?;
-        let result = self.transport.create_push_config(&params, req).await;
+        let patched = TaskPushNotificationConfig {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.create_push_config(&params, &patched).await;
         self.finish_call(methods::CREATE_PUSH_CONFIG, result).await
     }
 
@@ -130,7 +168,11 @@ impl<T: Transport> A2AClient<T> {
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::GET_PUSH_CONFIG).await?;
-        let result = self.transport.get_push_config(&params, req).await;
+        let patched = GetTaskPushNotificationConfigRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.get_push_config(&params, &patched).await;
         self.finish_call(methods::GET_PUSH_CONFIG, result).await
     }
 
@@ -139,7 +181,11 @@ impl<T: Transport> A2AClient<T> {
         req: &ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
         let params = self.apply_before(methods::LIST_PUSH_CONFIGS).await?;
-        let result = self.transport.list_push_configs(&params, req).await;
+        let patched = ListTaskPushNotificationConfigsRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.list_push_configs(&params, &patched).await;
         self.finish_call(methods::LIST_PUSH_CONFIGS, result).await
     }
 
@@ -148,7 +194,11 @@ impl<T: Transport> A2AClient<T> {
         req: &DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         let params = self.apply_before(methods::DELETE_PUSH_CONFIG).await?;
-        let result = self.transport.delete_push_config(&params, req).await;
+        let patched = DeleteTaskPushNotificationConfigRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self.transport.delete_push_config(&params, &patched).await;
         self.finish_call(methods::DELETE_PUSH_CONFIG, result).await
     }
 
@@ -157,7 +207,14 @@ impl<T: Transport> A2AClient<T> {
         req: &GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
         let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
-        let result = self.transport.get_extended_agent_card(&params, req).await;
+        let patched = GetExtendedAgentCardRequest {
+            tenant: self.tenant.clone(),
+            ..req.clone()
+        };
+        let result = self
+            .transport
+            .get_extended_agent_card(&params, &patched)
+            .await;
         self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
             .await
     }

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -178,10 +178,7 @@ impl<T: Transport> A2AClient<T> {
     ) -> Result<AgentCard, A2AError> {
         let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
         req.tenant = self.tenant.clone();
-        let result = self
-            .transport
-            .get_extended_agent_card(&params, &req)
-            .await;
+        let result = self.transport.get_extended_agent_card(&params, &req).await;
         self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
             .await
     }

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -79,141 +79,108 @@ impl<T: Transport> A2AClient<T> {
 
     pub async fn send_message(
         &self,
-        req: &SendMessageRequest,
+        mut req: SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
         let params = self.apply_before(methods::SEND_MESSAGE).await?;
-        let patched = SendMessageRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.send_message(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.send_message(&params, &req).await;
         self.finish_call(methods::SEND_MESSAGE, result).await
     }
 
     pub async fn send_streaming_message(
         &self,
-        req: &SendMessageRequest,
+        mut req: SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SEND_STREAMING_MESSAGE).await?;
-        let patched = SendMessageRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self
-            .transport
-            .send_streaming_message(&params, &patched)
-            .await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.send_streaming_message(&params, &req).await;
         self.finish_call(methods::SEND_STREAMING_MESSAGE, result)
             .await
     }
 
-    pub async fn get_task(&self, req: &GetTaskRequest) -> Result<Task, A2AError> {
+    pub async fn get_task(&self, mut req: GetTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::GET_TASK).await?;
-        let patched = GetTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.get_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.get_task(&params, &req).await;
         self.finish_call(methods::GET_TASK, result).await
     }
 
-    pub async fn list_tasks(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
+    pub async fn list_tasks(
+        &self,
+        mut req: ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
         let params = self.apply_before(methods::LIST_TASKS).await?;
-        let patched = ListTasksRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.list_tasks(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.list_tasks(&params, &req).await;
         self.finish_call(methods::LIST_TASKS, result).await
     }
 
-    pub async fn cancel_task(&self, req: &CancelTaskRequest) -> Result<Task, A2AError> {
+    pub async fn cancel_task(&self, mut req: CancelTaskRequest) -> Result<Task, A2AError> {
         let params = self.apply_before(methods::CANCEL_TASK).await?;
-        let patched = CancelTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.cancel_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.cancel_task(&params, &req).await;
         self.finish_call(methods::CANCEL_TASK, result).await
     }
 
     pub async fn subscribe_to_task(
         &self,
-        req: &SubscribeToTaskRequest,
+        mut req: SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let params = self.apply_before(methods::SUBSCRIBE_TO_TASK).await?;
-        let patched = SubscribeToTaskRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.subscribe_to_task(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.subscribe_to_task(&params, &req).await;
         self.finish_call(methods::SUBSCRIBE_TO_TASK, result).await
     }
 
     pub async fn create_push_config(
         &self,
-        req: &TaskPushNotificationConfig,
+        mut req: TaskPushNotificationConfig,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::CREATE_PUSH_CONFIG).await?;
-        let patched = TaskPushNotificationConfig {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.create_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.create_push_config(&params, &req).await;
         self.finish_call(methods::CREATE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_push_config(
         &self,
-        req: &GetTaskPushNotificationConfigRequest,
+        mut req: GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         let params = self.apply_before(methods::GET_PUSH_CONFIG).await?;
-        let patched = GetTaskPushNotificationConfigRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.get_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.get_push_config(&params, &req).await;
         self.finish_call(methods::GET_PUSH_CONFIG, result).await
     }
 
     pub async fn list_push_configs(
         &self,
-        req: &ListTaskPushNotificationConfigsRequest,
+        mut req: ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
         let params = self.apply_before(methods::LIST_PUSH_CONFIGS).await?;
-        let patched = ListTaskPushNotificationConfigsRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.list_push_configs(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.list_push_configs(&params, &req).await;
         self.finish_call(methods::LIST_PUSH_CONFIGS, result).await
     }
 
     pub async fn delete_push_config(
         &self,
-        req: &DeleteTaskPushNotificationConfigRequest,
+        mut req: DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         let params = self.apply_before(methods::DELETE_PUSH_CONFIG).await?;
-        let patched = DeleteTaskPushNotificationConfigRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
-        let result = self.transport.delete_push_config(&params, &patched).await;
+        req.tenant = self.tenant.clone();
+        let result = self.transport.delete_push_config(&params, &req).await;
         self.finish_call(methods::DELETE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_extended_agent_card(
         &self,
-        req: &GetExtendedAgentCardRequest,
+        mut req: GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
         let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
-        let patched = GetExtendedAgentCardRequest {
-            tenant: self.tenant.clone(),
-            ..req.clone()
-        };
+        req.tenant = self.tenant.clone();
         let result = self
             .transport
-            .get_extended_agent_card(&params, &patched)
+            .get_extended_agent_card(&params, &req)
             .await;
         self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
             .await
@@ -246,7 +213,7 @@ impl<T: Transport> SendMessageExt for A2AClient<T> {
             metadata: None,
             tenant: None,
         };
-        self.send_message(&req).await
+        self.send_message(req).await
     }
 }
 
@@ -533,7 +500,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let resp = client.send_message(&req).await.unwrap();
+        let resp = client.send_message(req).await.unwrap();
         assert!(matches!(resp, SendMessageResponse::Task(_)));
     }
 
@@ -559,7 +526,7 @@ mod tests {
             tenant: None,
         };
 
-        client.send_message(&req).await.unwrap();
+        client.send_message(req).await.unwrap();
 
         let calls = state.calls.lock().unwrap();
         let params = &calls[0].1;
@@ -598,7 +565,7 @@ mod tests {
             tenant: None,
         };
 
-        let err = client.send_message(&req).await.unwrap_err();
+        let err = client.send_message(req).await.unwrap_err();
         assert_eq!(err.message, "boom");
 
         let events = events.lock().unwrap().clone();
@@ -618,7 +585,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let mut stream = client.send_streaming_message(&req).await.unwrap();
+        let mut stream = client.send_streaming_message(req).await.unwrap();
         let item = stream.next().await.unwrap().unwrap();
         assert!(matches!(item, StreamResponse::StatusUpdate(_)));
     }
@@ -631,7 +598,7 @@ mod tests {
             history_length: None,
             tenant: None,
         };
-        let task = client.get_task(&req).await.unwrap();
+        let task = client.get_task(req).await.unwrap();
         assert_eq!(task.id, "t1");
     }
 
@@ -648,7 +615,7 @@ mod tests {
             include_artifacts: None,
             tenant: None,
         };
-        let resp = client.list_tasks(&req).await.unwrap();
+        let resp = client.list_tasks(req).await.unwrap();
         assert!(resp.tasks.is_empty());
     }
 
@@ -660,7 +627,7 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let task = client.cancel_task(&req).await.unwrap();
+        let task = client.cancel_task(req).await.unwrap();
         assert_eq!(task.status.state, TaskState::Canceled);
     }
 
@@ -671,7 +638,7 @@ mod tests {
             id: "t1".into(),
             tenant: None,
         };
-        let _stream = client.subscribe_to_task(&req).await.unwrap();
+        let _stream = client.subscribe_to_task(req).await.unwrap();
     }
 
     #[tokio::test]
@@ -685,7 +652,7 @@ mod tests {
             authentication: None,
             tenant: None,
         };
-        let resp = client.create_push_config(&req).await.unwrap();
+        let resp = client.create_push_config(req).await.unwrap();
         assert_eq!(resp.task_id, "t1");
     }
 
@@ -697,7 +664,7 @@ mod tests {
             id: "cfg1".into(),
             tenant: None,
         };
-        let resp = client.get_push_config(&req).await.unwrap();
+        let resp = client.get_push_config(req).await.unwrap();
         assert_eq!(resp.id, Some("cfg1".into()));
     }
 
@@ -710,7 +677,7 @@ mod tests {
             page_token: None,
             tenant: None,
         };
-        let resp = client.list_push_configs(&req).await.unwrap();
+        let resp = client.list_push_configs(req).await.unwrap();
         assert!(resp.configs.is_empty());
     }
 
@@ -722,14 +689,14 @@ mod tests {
             id: "cfg1".into(),
             tenant: None,
         };
-        client.delete_push_config(&req).await.unwrap();
+        client.delete_push_config(req).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_extended_agent_card() {
         let client = make_client();
         let req = GetExtendedAgentCardRequest { tenant: None };
-        let card = client.get_extended_agent_card(&req).await.unwrap();
+        let card = client.get_extended_agent_card(req).await.unwrap();
         assert_eq!(card.name, "Test");
     }
 

--- a/a2a-client/src/factory.rs
+++ b/a2a-client/src/factory.rs
@@ -100,9 +100,9 @@ impl A2AClientFactory {
         for (_prio, iface, factory) in &candidates {
             match factory.create(card, iface).await {
                 Ok(transport) => {
-                    return Ok(
-                        A2AClient::new(transport).with_interceptors(self.interceptors.clone())
-                    );
+                    return Ok(A2AClient::new(transport)
+                        .with_tenant(iface.tenant.clone())
+                        .with_interceptors(self.interceptors.clone()));
                 }
                 Err(e) => {
                     tracing::debug!(

--- a/a2a-client/src/factory.rs
+++ b/a2a-client/src/factory.rs
@@ -96,10 +96,26 @@ impl A2AClientFactory {
         // Sort by preference (lower is better)
         candidates.sort_by_key(|(prio, _, _)| *prio);
 
+        tracing::info!(
+            candidates = ?candidates.iter().map(|(_, iface, _)| &iface.protocol_binding).collect::<Vec<_>>(),
+            preferred = ?self.preferred_bindings,
+            "negotiating transport binding"
+        );
+
         let mut last_err = None;
         for (_prio, iface, factory) in &candidates {
+            tracing::info!(
+                protocol = %iface.protocol_binding,
+                url = %iface.url,
+                "trying transport binding"
+            );
             match factory.create(card, iface).await {
                 Ok(transport) => {
+                    tracing::info!(
+                        protocol = %iface.protocol_binding,
+                        url = %iface.url,
+                        "selected transport binding"
+                    );
                     return Ok(A2AClient::new(transport)
                         .with_tenant(iface.tenant.clone())
                         .with_interceptors(self.interceptors.clone()));

--- a/a2a-client/src/jsonrpc.rs
+++ b/a2a-client/src/jsonrpc.rs
@@ -616,7 +616,7 @@ mod tests {
         let result_val = protojson_conv::to_value(&sr).unwrap();
         let rpc_resp = JsonRpcResponse::success(JsonRpcId::Number(1), result_val);
         let data = serde_json::to_string(&rpc_resp).unwrap();
-        let sse_text = format!("data: {}\n\n", data);
+        let sse_text = format!("data: {data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream(stream);
@@ -636,7 +636,7 @@ mod tests {
             },
         );
         let data = serde_json::to_string(&rpc_resp).unwrap();
-        let sse_text = format!("data: {}\n\n", data);
+        let sse_text = format!("data: {data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream(stream);
@@ -659,7 +659,7 @@ mod tests {
         };
         let sr = StreamResponse::StatusUpdate(status_update);
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
-        let sse_text = format!("data: {}\n\n", data);
+        let sse_text = format!("data: {data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream(stream);
@@ -681,7 +681,7 @@ mod tests {
         };
         let sr = StreamResponse::StatusUpdate(status_update);
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
-        let sse_text = format!("data: {}\n\n", data);
+        let sse_text = format!("data: {data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream_rest(stream);
@@ -713,7 +713,7 @@ mod tests {
         });
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
         // First event has no data, second has data
-        let sse_text = format!("event: ping\n\ndata: {}\n\n", data);
+        let sse_text = format!("event: ping\n\ndata: {data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream_rest(stream);
@@ -735,7 +735,7 @@ mod tests {
             metadata: None,
         });
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
-        let full = format!("data: {}\n\n", data);
+        let full = format!("data: {data}\n\n");
         let mid = full.len() / 2;
         let chunk1 = full[..mid].to_string();
         let chunk2 = full[mid..].to_string();
@@ -760,7 +760,7 @@ mod tests {
             metadata: None,
         });
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
-        let sse_text = format!("data:{}\n\n", data);
+        let sse_text = format!("data:{data}\n\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream_rest(stream);
@@ -789,8 +789,8 @@ mod tests {
             &protojson_conv::to_value(&make_sr(TaskState::Completed)).unwrap(),
         )
         .unwrap();
-        let chunk1 = format!("data: {}\n\n", sr1);
-        let chunk2 = format!("data: {}\n\n", sr2);
+        let chunk1 = format!("data: {sr1}\n\n");
+        let chunk2 = format!("data: {sr2}\n\n");
 
         let stream = byte_stream(vec![chunk1, chunk2]);
         let items: Vec<_> = parse_sse_stream_rest(stream).collect().await;
@@ -1075,7 +1075,7 @@ mod tests {
         });
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
         // Use \r\n\r\n instead of \n\n
-        let sse_text = format!("data: {}\r\n\r\n", data);
+        let sse_text = format!("data: {data}\r\n\r\n");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream(stream);
@@ -1098,7 +1098,7 @@ mod tests {
             metadata: None,
         });
         let data = serde_json::to_string(&protojson_conv::to_value(&sr).unwrap()).unwrap();
-        let sse_text = format!("data: {}\r\r", data);
+        let sse_text = format!("data: {data}\r\r");
 
         let stream = byte_stream(vec![sse_text]);
         let mut parsed = parse_sse_stream_rest(stream);

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -1265,7 +1265,7 @@ mod tests {
 
         let app = make_app();
         let req = Request::builder()
-            .uri(format!("/tasks/{}?historyLength=5", task_id))
+            .uri(format!("/tasks/{task_id}?historyLength=5"))
             .method("GET")
             .body(Body::empty())
             .unwrap();

--- a/a2a-slimrpc/Cargo.toml
+++ b/a2a-slimrpc/Cargo.toml
@@ -22,9 +22,9 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 slim_rpc = { workspace = true }
 slim_service = { workspace = true }
+slim_config = { workspace = true }
 slim_datapath = { workspace = true }
 slim_auth = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-slim_config = { workspace = true }

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -358,10 +358,11 @@ impl SlimRpcTransportFactory {
 
 async fn create_app_from_slim_config() -> Result<Arc<slim_bindings::App>, a2a::A2AError> {
     slim_bindings::initialize_with_defaults();
-    let config = slim_bindings::load_slim_config()
+    let config = slim_bindings::load_slim_config(None)
         .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
     slim_bindings::get_global_service()
-        .create_app_from_slim_config(config)
+        .create_app_from_slim_config_async(config).await
+        .map(|h| h.app)
         .map_err(|e| a2a::A2AError::internal(e.to_string()))
 }
 

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -57,8 +57,8 @@ impl SlimRpcTransport {
     pub async fn from_slim_config(
         remote: Arc<slim_bindings::Name>,
     ) -> Result<Self, a2a::A2AError> {
-        let app = create_app_from_slim_config().await?;
-        Ok(Self::new(app, remote))
+        let (app, conn_id) = create_app_from_slim_config().await?;
+        Ok(Self::new_with_connection(app, remote, Some(conn_id)))
     }
 
     async fn call_unary<Req, Res>(
@@ -351,18 +351,19 @@ impl SlimRpcTransportFactory {
     /// `~/.slim/config.yaml`), with environment variables taking highest priority. Initializes
     /// the global SLIM service, connects to the node, and subscribes the local app.
     pub async fn from_slim_config() -> Result<Self, a2a::A2AError> {
-        let app = create_app_from_slim_config().await?;
-        Ok(Self::new(app))
+        let (app, conn_id) = create_app_from_slim_config().await?;
+        Ok(Self::new_with_connection(app, Some(conn_id)))
     }
 }
 
-async fn create_app_from_slim_config() -> Result<Arc<slim_bindings::App>, a2a::A2AError> {
+async fn create_app_from_slim_config() -> Result<(Arc<slim_bindings::App>, u64), a2a::A2AError> {
     slim_bindings::initialize_with_defaults();
     let config = slim_bindings::load_slim_config(None)
         .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
     slim_bindings::get_global_service()
-        .create_app_from_slim_config_async(config).await
-        .map(|h| h.app)
+        .create_app_from_slim_config_async(config)
+        .await
+        .map(|h| (h.app, h.conn_id))
         .map_err(|e| a2a::A2AError::internal(e.to_string()))
 }
 

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -49,6 +49,18 @@ impl SlimRpcTransport {
         Self { channel }
     }
 
+    /// Create a transport by loading connection and identity config from `slim.yaml`.
+    ///
+    /// Discovers `slim.yaml` walking up from the current working directory (falling back to
+    /// `~/.slim/config.yaml`), with environment variables taking highest priority. Initializes
+    /// the global SLIM service, connects to the node, and subscribes the local app.
+    pub async fn from_slim_config(
+        remote: Arc<slim_bindings::Name>,
+    ) -> Result<Self, a2a::A2AError> {
+        let app = create_app_from_slim_config().await?;
+        Ok(Self::new(app, remote))
+    }
+
     async fn call_unary<Req, Res>(
         &self,
         params: &ServiceParams,
@@ -332,6 +344,25 @@ impl SlimRpcTransportFactory {
     pub fn new_with_connection(app: Arc<SlimApp>, connection_id: Option<u64>) -> Self {
         Self { app, connection_id }
     }
+
+    /// Create a factory by loading connection and identity config from `slim.yaml`.
+    ///
+    /// Discovers `slim.yaml` walking up from the current working directory (falling back to
+    /// `~/.slim/config.yaml`), with environment variables taking highest priority. Initializes
+    /// the global SLIM service, connects to the node, and subscribes the local app.
+    pub async fn from_slim_config() -> Result<Self, a2a::A2AError> {
+        let app = create_app_from_slim_config().await?;
+        Ok(Self::new(app))
+    }
+}
+
+async fn create_app_from_slim_config() -> Result<Arc<slim_bindings::App>, a2a::A2AError> {
+    slim_bindings::initialize_with_defaults();
+    let config = slim_bindings::load_slim_config()
+        .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
+    slim_bindings::get_global_service()
+        .create_app_from_slim_config(config)
+        .map_err(|e| a2a::A2AError::internal(e.to_string()))
 }
 
 #[async_trait]

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -25,40 +25,104 @@ use crate::common::{
 };
 use crate::errors::rpc_error_to_a2a_error;
 
+// ---------------------------------------------------------------------------
+// SlimRpcTransport
+// ---------------------------------------------------------------------------
+
 /// SLIMRPC transport for A2A clients.
 pub struct SlimRpcTransport {
     channel: slim_rpc::Channel,
+    _service: Option<Arc<slim_service::Service>>,
+}
+
+/// Builder for [`SlimRpcTransport`].
+#[derive(Default)]
+pub struct SlimRpcTransportBuilder {
+    app: Option<Arc<SlimApp>>,
+    remote: Option<Arc<ProtoName>>,
+    connection_id: Option<u64>,
+    service: Option<Arc<slim_service::Service>>,
+    channel: Option<slim_rpc::Channel>,
+    use_slim_config: bool,
+}
+
+impl SlimRpcTransportBuilder {
+    pub fn with_app(mut self, app: Arc<SlimApp>) -> Self {
+        self.app = Some(app);
+        self
+    }
+
+    pub fn with_remote(mut self, remote: Arc<ProtoName>) -> Self {
+        self.remote = Some(remote);
+        self
+    }
+
+    pub fn with_connection(mut self, conn_id: u64) -> Self {
+        self.connection_id = Some(conn_id);
+        self
+    }
+
+    /// Keep an existing [`slim_service::Service`] alive for the lifetime of this transport.
+    /// When combined with [`with_slim_config`], the provided service is used instead of
+    /// creating a new one.
+    pub fn with_service(mut self, service: Arc<slim_service::Service>) -> Self {
+        self.service = Some(service);
+        self
+    }
+
+    /// Use a pre-built [`slim_rpc::Channel`] directly, bypassing app/remote/connection.
+    pub fn with_channel(mut self, channel: slim_rpc::Channel) -> Self {
+        self.channel = Some(channel);
+        self
+    }
+
+    /// Load connection and identity config from `slim.yaml` (walks up from cwd, falls back
+    /// to `~/.slim/config.yaml`). If [`with_service`] was also called, that service is reused;
+    /// otherwise a new one is created. Requires [`with_remote`].
+    pub fn with_slim_config(mut self) -> Self {
+        self.use_slim_config = true;
+        self
+    }
+
+    pub async fn build(self) -> Result<SlimRpcTransport, a2a::A2AError> {
+        if let Some(channel) = self.channel {
+            return Ok(SlimRpcTransport {
+                channel,
+                _service: self.service,
+            });
+        }
+
+        if self.use_slim_config {
+            let remote = self.remote.ok_or_else(|| {
+                a2a::A2AError::internal("remote is required when using slim config")
+            })?;
+            let (service, handle) = build_app_from_slim_config(self.service).await?;
+            return Ok(SlimRpcTransport {
+                channel: slim_rpc::Channel::new_with_connection(
+                    Arc::new(handle.app),
+                    remote,
+                    Some(handle.conn_id),
+                ),
+                _service: Some(service),
+            });
+        }
+
+        let app = self
+            .app
+            .ok_or_else(|| a2a::A2AError::internal("app is required"))?;
+        let remote = self
+            .remote
+            .ok_or_else(|| a2a::A2AError::internal("remote is required"))?;
+        Ok(SlimRpcTransport {
+            channel: slim_rpc::Channel::new_with_connection(app, remote, self.connection_id),
+            _service: self.service,
+        })
+    }
 }
 
 impl SlimRpcTransport {
-    pub fn new(app: Arc<SlimApp>, remote: Arc<ProtoName>) -> Self {
-        Self::new_with_connection(app, remote, None)
-    }
-
-    pub fn new_with_connection(
-        app: Arc<SlimApp>,
-        remote: Arc<ProtoName>,
-        connection_id: Option<u64>,
-    ) -> Self {
-        Self {
-            channel: slim_rpc::Channel::new_with_connection(app, remote, connection_id),
-        }
-    }
-
-    pub fn from_channel(channel: slim_rpc::Channel) -> Self {
-        Self { channel }
-    }
-
-    /// Create a transport by loading connection and identity config from `slim.yaml`.
-    ///
-    /// Discovers `slim.yaml` walking up from the current working directory (falling back to
-    /// `~/.slim/config.yaml`), with environment variables taking highest priority. Initializes
-    /// the global SLIM service, connects to the node, and subscribes the local app.
-    pub async fn from_slim_config(
-        remote: Arc<slim_bindings::Name>,
-    ) -> Result<Self, a2a::A2AError> {
-        let (app, conn_id) = create_app_from_slim_config().await?;
-        Ok(Self::new_with_connection(app, remote, Some(conn_id)))
+    pub fn builder() -> SlimRpcTransportBuilder {
+        SlimRpcTransportBuilder::default()
     }
 
     async fn call_unary<Req, Res>(
@@ -327,44 +391,78 @@ impl Transport for SlimRpcTransport {
     }
 }
 
+// ---------------------------------------------------------------------------
+// SlimRpcTransportFactory
+// ---------------------------------------------------------------------------
+
 #[derive(Clone)]
 pub struct SlimRpcTransportFactory {
     app: Arc<SlimApp>,
     connection_id: Option<u64>,
+    _service: Option<Arc<slim_service::Service>>,
+}
+
+/// Builder for [`SlimRpcTransportFactory`].
+#[derive(Default)]
+pub struct SlimRpcTransportFactoryBuilder {
+    app: Option<Arc<SlimApp>>,
+    connection_id: Option<u64>,
+    service: Option<Arc<slim_service::Service>>,
+    use_slim_config: bool,
+}
+
+impl SlimRpcTransportFactoryBuilder {
+    pub fn with_app(mut self, app: Arc<SlimApp>) -> Self {
+        self.app = Some(app);
+        self
+    }
+
+    pub fn with_connection(mut self, conn_id: u64) -> Self {
+        self.connection_id = Some(conn_id);
+        self
+    }
+
+    /// Keep an existing [`slim_service::Service`] alive for the lifetime of this factory (and
+    /// all transports it creates). When combined with [`with_slim_config`], the provided service
+    /// is reused instead of creating a new one.
+    pub fn with_service(mut self, service: Arc<slim_service::Service>) -> Self {
+        self.service = Some(service);
+        self
+    }
+
+    /// Load connection and identity config from `slim.yaml` (walks up from cwd, falls back to
+    /// `~/.slim/config.yaml`). If [`with_service`] was also called, that service is reused;
+    /// otherwise a new one is created.
+    pub fn with_slim_config(mut self) -> Self {
+        self.use_slim_config = true;
+        self
+    }
+
+    pub async fn build(self) -> Result<SlimRpcTransportFactory, a2a::A2AError> {
+        if self.use_slim_config {
+            let (service, handle) = build_app_from_slim_config(self.service).await?;
+            return Ok(SlimRpcTransportFactory {
+                app: Arc::new(handle.app),
+                connection_id: Some(handle.conn_id),
+                _service: Some(service),
+            });
+        }
+
+        let app = self
+            .app
+            .ok_or_else(|| a2a::A2AError::internal("app is required"))?;
+        Ok(SlimRpcTransportFactory {
+            app,
+            connection_id: self.connection_id,
+            _service: self.service,
+        })
+    }
 }
 
 impl SlimRpcTransportFactory {
-    pub fn new(app: Arc<SlimApp>) -> Self {
-        Self {
-            app,
-            connection_id: None,
-        }
+    pub fn builder() -> SlimRpcTransportFactoryBuilder {
+        SlimRpcTransportFactoryBuilder::default()
     }
-
-    pub fn new_with_connection(app: Arc<SlimApp>, connection_id: Option<u64>) -> Self {
-        Self { app, connection_id }
-    }
-
-    /// Create a factory by loading connection and identity config from `slim.yaml`.
-    ///
-    /// Discovers `slim.yaml` walking up from the current working directory (falling back to
-    /// `~/.slim/config.yaml`), with environment variables taking highest priority. Initializes
-    /// the global SLIM service, connects to the node, and subscribes the local app.
-    pub async fn from_slim_config() -> Result<Self, a2a::A2AError> {
-        let (app, conn_id) = create_app_from_slim_config().await?;
-        Ok(Self::new_with_connection(app, Some(conn_id)))
-    }
-}
-
-async fn create_app_from_slim_config() -> Result<(Arc<slim_bindings::App>, u64), a2a::A2AError> {
-    slim_bindings::initialize_with_defaults();
-    let config = slim_bindings::load_slim_config(None)
-        .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
-    slim_bindings::get_global_service()
-        .create_app_from_slim_config_async(config)
-        .await
-        .map(|h| (h.app, h.conn_id))
-        .map_err(|e| a2a::A2AError::internal(e.to_string()))
 }
 
 #[async_trait]
@@ -379,11 +477,49 @@ impl TransportFactory for SlimRpcTransportFactory {
         iface: &AgentInterface,
     ) -> Result<Box<dyn Transport>, A2AError> {
         let remote = parse_slimrpc_target(&iface.url)?;
-        let transport =
-            SlimRpcTransport::new_with_connection(self.app.clone(), remote, self.connection_id);
+        let transport = SlimRpcTransport {
+            channel: slim_rpc::Channel::new_with_connection(
+                self.app.clone(),
+                remote,
+                self.connection_id,
+            ),
+            _service: self._service.clone(),
+        };
         Ok(Box::new(transport))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Shared slim config helper
+// ---------------------------------------------------------------------------
+
+/// Connect to a SLIM node using the discovered `slim.yaml` config. If `service` is `Some`,
+/// it is reused; otherwise a new [`slim_service::Service`] is created. Returns the service
+/// (wrapped in `Arc`) and the app handle.
+async fn build_app_from_slim_config(
+    service: Option<Arc<slim_service::Service>>,
+) -> Result<(Arc<slim_service::Service>, slim_service::AppHandle), a2a::A2AError> {
+    use slim_config::component::ComponentBuilder as _;
+    let config = slim_service::node_config::load_slim_node_config(None)
+        .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
+    let service = match service {
+        Some(svc) => svc,
+        None => Arc::new(
+            slim_service::Service::builder()
+                .build("a2a-slimrpc".to_string())
+                .map_err(|e| a2a::A2AError::internal(e.to_string()))?,
+        ),
+    };
+    let handle = service
+        .create_app_from_slim_config(config)
+        .await
+        .map_err(|e| a2a::A2AError::internal(e.to_string()))?;
+    Ok((service, handle))
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing
+// ---------------------------------------------------------------------------
 
 /// Parse a SLIMRPC target from agent card interface data.
 pub fn parse_slimrpc_target(target: &str) -> Result<Arc<ProtoName>, A2AError> {

--- a/a2a-slimrpc/tests/e2e.rs
+++ b/a2a-slimrpc/tests/e2e.rs
@@ -163,28 +163,50 @@ impl TestEnv {
 
     async fn transport(&self, suffix: &str) -> SlimRpcTransport {
         let client_app = self.new_client_app(suffix).await;
-        SlimRpcTransport::new(client_app, self.server_name.clone())
+        SlimRpcTransport::builder()
+            .with_app(client_app)
+            .with_remote(self.server_name.clone())
+            .build()
+            .await
+            .unwrap()
     }
 
     async fn transport_with_connection(&self, suffix: &str) -> SlimRpcTransport {
         let client_app = self.new_client_app(suffix).await;
-        SlimRpcTransport::new_with_connection(client_app, self.server_name.clone(), None)
+        SlimRpcTransport::builder()
+            .with_app(client_app)
+            .with_remote(self.server_name.clone())
+            .build()
+            .await
+            .unwrap()
     }
 
     async fn transport_from_channel(&self, suffix: &str) -> SlimRpcTransport {
         let client_app = self.new_client_app(suffix).await;
         let channel = Channel::new(client_app, self.server_name.clone());
-        SlimRpcTransport::from_channel(channel)
+        SlimRpcTransport::builder()
+            .with_channel(channel)
+            .build()
+            .await
+            .unwrap()
     }
 
     async fn factory(&self, suffix: &str) -> SlimRpcTransportFactory {
         let client_app = self.new_client_app(suffix).await;
-        SlimRpcTransportFactory::new(client_app)
+        SlimRpcTransportFactory::builder()
+            .with_app(client_app)
+            .build()
+            .await
+            .unwrap()
     }
 
     async fn factory_with_connection(&self, suffix: &str) -> SlimRpcTransportFactory {
         let client_app = self.new_client_app(suffix).await;
-        SlimRpcTransportFactory::new_with_connection(client_app, None)
+        SlimRpcTransportFactory::builder()
+            .with_app(client_app)
+            .build()
+            .await
+            .unwrap()
     }
 
     fn target(&self) -> String {

--- a/a2a/src/types.rs
+++ b/a2a/src/types.rs
@@ -955,7 +955,7 @@ mod tests {
 
         for (state, expected_str) in cases {
             let json = serde_json::to_string(&state).unwrap();
-            assert_eq!(json, format!("\"{}\"", expected_str));
+            assert_eq!(json, format!("\"{expected_str}\""));
             let back: TaskState = serde_json::from_str(&json).unwrap();
             assert_eq!(back, state);
         }

--- a/a2acli-skill/SKILL.md
+++ b/a2acli-skill/SKILL.md
@@ -1,0 +1,127 @@
+# a2acli skill
+
+Use this skill to interact with A2A-compatible agents from the command line using the `a2a` binary.
+
+## When to use
+
+- Inspect an agent's capabilities by fetching its agent card
+- Send one-shot or streaming messages to an A2A agent
+- Retrieve, list, cancel, or subscribe to tasks on an agent
+- Manage push notification configs for tasks
+- Diagnose A2A agent deployments or script A2A workflows in a shell
+
+## Install
+
+```sh
+# macOS
+brew tap a2aproject/a2a-rs https://github.com/a2aproject/a2a-rs
+brew trust a2aproject/a2a-rs
+brew install a2acli
+
+# Linux
+curl -fsSL https://raw.githubusercontent.com/a2aproject/a2a-rs/main/install.sh | bash
+
+# From source
+cargo install a2a-cli
+```
+
+## Usage patterns
+
+### Agent reference (`AGENT_REF`)
+
+Every command takes an `AGENT_REF` as its first positional argument:
+
+| Value | Behaviour |
+| --- | --- |
+| `http://host` or `https://host` | Card is fetched from `<URL>/.well-known/agent-card.json`. |
+| Any `http`/`https` URL ending in `.json` | Used as-is — a direct link to the agent card JSON. |
+| Any other value | Treated as a local filesystem path and read directly. |
+
+```sh
+a2a discover http://localhost:3000                        # base URL
+a2a discover https://example.com/agents/my-agent.json    # direct card URL
+a2a discover ./agent-card.json                           # local file
+```
+
+### Discover an agent
+
+```sh
+a2a discover <AGENT_REF>
+a2a discover <AGENT_REF> --extended
+```
+
+### Send a message
+
+```sh
+# One-shot — prints the completed task
+a2a send <AGENT_REF> "<message>"
+
+# With context and task identity
+a2a send <AGENT_REF> "<message>" --context-id <ctx> --task-id <task>
+
+# Streaming — prints events as they arrive
+a2a stream <AGENT_REF> "<message>"
+```
+
+### Manage tasks
+
+```sh
+a2a task get    <AGENT_REF> <TASK_ID>
+a2a task list   <AGENT_REF> [--status completed] [--context-id <ctx>]
+a2a task cancel <AGENT_REF> <TASK_ID>
+a2a task subscribe <AGENT_REF> <TASK_ID>   # stream live events
+```
+
+### Push notification configs
+
+```sh
+a2a push-config create <AGENT_REF> <TASK_ID> <CALLBACK_URL> \
+  --auth-scheme Bearer --auth-credentials <secret>
+
+a2a push-config list   <AGENT_REF> <TASK_ID>
+a2a push-config get    <AGENT_REF> <TASK_ID> <CONFIG_ID>
+a2a push-config delete <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+## Global flags
+
+| Flag | Env var | Description |
+| --- | --- | --- |
+| `--enabled-binding jsonrpc\|http-json` | | Pin the transport binding. Repeatable. Auto-negotiated if omitted. |
+| `--bearer-token <TOKEN>` | `A2A_BEARER_TOKEN` | Bearer token sent with every request. |
+| `--header <Name:Value>` | | Custom HTTP header. Repeatable. |
+| `-o pretty\|json` | | Output format. `pretty` = indented JSON (default). `json` = compact, one object per line. |
+
+## Config file
+
+Create `.a2a.yaml` in any ancestor directory (up to `$HOME`) to set defaults:
+
+```yaml
+enabled_bindings:
+  - http-json
+bearer_token: my-token
+headers:
+  - "X-Tenant: acme"
+output: json
+```
+
+CLI flags always win over config file values. Headers are additive.
+
+## Pipe-friendly output
+
+Use `-o json` with `jq` for scripting:
+
+```sh
+# Get the agent name
+a2a -o json discover http://localhost:3000 | jq -r '.name'
+
+# Watch task state from a stream
+a2a -o json stream http://localhost:3000 "hello" | jq -r '.statusUpdate.status.state // empty'
+
+# List completed task IDs
+a2a -o json task list http://localhost:3000 --status completed | jq -r '.tasks[].id'
+```
+
+## Reference
+
+Full documentation: [`a2acli/README.md`](../a2acli/README.md)

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/main.rs"
 [dependencies]
 a2a = { workspace = true }
 a2a-client = { workspace = true }
+a2a-slimrpc = { workspace = true, optional = true }
+slim_bindings = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive", "env"] }
 futures = { workspace = true }
 reqwest = { workspace = true }
@@ -31,6 +33,7 @@ tokio = { workspace = true }
 default = ["rustls-tls"]
 native-tls = ["a2a-client/native-tls", "reqwest/native-tls"]
 rustls-tls = ["a2a-client/rustls-tls", "reqwest/rustls"]
+slimrpc = ["dep:a2a-slimrpc", "dep:slim_bindings"]
 
 [dev-dependencies]
 a2a-server = { workspace = true }

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/main.rs"
 a2a = { workspace = true }
 a2a-client = { workspace = true }
 a2a-slimrpc = { workspace = true, optional = true }
-slim_bindings = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive", "env"] }
 futures = { workspace = true }
 reqwest = { workspace = true }
@@ -28,12 +27,13 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["rustls-tls"]
 native-tls = ["a2a-client/native-tls", "reqwest/native-tls"]
 rustls-tls = ["a2a-client/rustls-tls", "reqwest/rustls"]
-slimrpc = ["dep:a2a-slimrpc", "dep:slim_bindings"]
+slimrpc = ["dep:a2a-slimrpc"]
 
 [dev-dependencies]
 a2a-server = { workspace = true }

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 name = "a2acli"
 
 [[bin]]
-name = "a2acli"
+name = "a2a"
 path = "src/main.rs"
 
 [dependencies]

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
@@ -36,3 +37,4 @@ a2a-server = { workspace = true }
 assert_cmd = "2"
 async-trait = { workspace = true }
 axum = { workspace = true }
+tempfile = "3"

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -1,45 +1,296 @@
 # a2acli
 
-Standalone A2A CLI client built on top of `a2a-client`.
-
-This crate is published as `a2a-cli` and installs the `a2acli` binary.
+Standalone A2A CLI client built on top of `a2a-client`. Published as `a2a-cli`; installs the `a2a` binary.
 
 ## Install
 
-From the workspace checkout:
+**macOS** — [Homebrew](https://brew.sh):
 
 ```sh
-cargo install --path a2acli
+brew tap a2aproject/a2a-rs https://github.com/a2aproject/a2a-rs
+brew trust a2aproject/a2a-rs
+brew install a2acli
 ```
 
-From crates.io after release:
+**Linux** — install script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/a2aproject/a2a-rs/main/install.sh | bash
+```
+
+Installs to `/usr/local/bin` as root or `~/.local/bin` otherwise. Override the destination with `A2A_CLI_INSTALL_DIR`.
+
+**Windows** — [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
+
+```sh
+winget install a2aproject.a2acli
+```
+
+**From source** — via [crates.io](https://crates.io/crates/a2a-cli):
 
 ```sh
 cargo install a2a-cli
 ```
 
-## What It Provides
-
-- Fetch and print the public agent card for an A2A deployment
-- Send one-shot or streaming messages
-- Inspect, list, cancel, and subscribe to tasks
-- Create, fetch, list, and delete task push notification configs
-- Request an extended agent card when the server exposes one
-- Add bearer-token or custom-header authentication to all requests
-
-## Run
+**From workspace checkout:**
 
 ```sh
-cargo run --bin a2acli -- card
-cargo run --bin a2acli -- send "hello from rust"
-cargo run --bin a2acli -- stream "hello from rust"
-cargo run --bin a2acli -- get-task task-123
-cargo run --bin a2acli -- push-config list task-123
-cargo run --bin a2acli -- push-config create task-123 https://example.com/callback --auth-scheme Bearer --auth-credentials secret
+cargo install --path a2acli
 ```
 
-By default the CLI targets `http://localhost:3000`. Use `--base-url` to point at
-another deployment and `--binding jsonrpc` or `--binding http-json` to pin the
-transport when the agent card exposes more than one compatible interface. The
-global `--tenant`, `--bearer-token`, and repeated `--header Name:Value` options
-also apply to push-config commands.
+## Quick start
+
+Every command takes an `AGENT_REF` as its first positional argument. This can be:
+
+- A base URL — the card is fetched from `<URL>/.well-known/agent-card.json`
+- A direct URL ending in `.json` — used as-is
+- A local file path — read from disk
+
+```sh
+# Base URL
+a2a discover http://localhost:3000
+
+# Direct URL to a card JSON
+a2a discover https://example.com/agents/my-agent.json
+
+# Local file
+a2a discover ./agent-card.json
+
+# Send a message (same AGENT_REF forms apply to all commands)
+a2a send http://localhost:3000 "hello"
+a2a stream http://localhost:3000 "hello"
+a2a task list http://localhost:3000
+a2a task get http://localhost:3000 <task-id>
+```
+
+## Global options
+
+These options apply to every subcommand.
+
+| Flag | Env var | Description |
+| --- | --- | --- |
+| `--enabled-binding <BINDING>` | | Pin the transport. `jsonrpc` or `http-json`. Repeatable. Auto-negotiated from the agent card if omitted. |
+| `--bearer-token <TOKEN>` | `A2A_BEARER_TOKEN` | Adds `Authorization: Bearer <TOKEN>` to all requests. |
+| `--header <Name:Value>` | | Adds a custom HTTP header to all requests. Repeatable. |
+| `-o, --output <FORMAT>` | | Output format: `pretty` (default, indented JSON) or `json` (compact, one object per line). |
+
+## Config file
+
+The CLI searches for `.a2a.yaml` starting from the current directory and walking up to `$HOME`. You can also place one in `$HOME/.a2a.yaml` as a fallback. CLI flags always override config file values; headers are additive (config headers come first, then CLI headers).
+
+```yaml
+# .a2a.yaml
+enabled_bindings:
+  - http-json          # jsonrpc | http-json
+bearer_token: my-token
+headers:
+  - "X-Tenant: acme"
+output: json           # pretty | json
+```
+
+## Commands
+
+### `discover`
+
+Fetch and print an agent's public card (or extended card with `--extended`).
+
+```sh
+a2a discover <AGENT_REF> [--extended]
+```
+
+`AGENT_REF` is resolved as follows:
+
+| Value | Behaviour |
+| --- | --- |
+| `http://host` or `https://host` | Appends `/.well-known/agent-card.json` and fetches it. |
+| Any `http`/`https` URL ending in `.json` | Used as-is — a direct link to the agent card JSON. |
+| Any other value | Treated as a local filesystem path and read directly. |
+
+```sh
+# Base URL — card is fetched from /.well-known/agent-card.json
+a2a discover http://localhost:3000
+
+# Direct URL to the card JSON
+a2a discover https://example.com/cards/my-agent.json
+
+# Local file
+a2a discover ./agent-card.json
+a2a discover /etc/a2a/staging-card.json
+
+# Extended card (requires the agent to support it)
+a2a discover http://localhost:3000 --extended
+```
+
+### `send`
+
+Send a one-shot message and print the resulting task.
+
+```sh
+a2a send <AGENT_REF> <TEXT> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--context-id <ID>` | Attach the message to an existing context. |
+| `--task-id <ID>` | Attach the message to an existing task. |
+| `--history-length <N>` | Number of history turns to request. |
+| `--accept-output <MIME>` | Accepted output modes. Repeatable. |
+| `--return-immediately` | Ask the agent to return immediately without waiting for completion. |
+
+```sh
+a2a send http://localhost:3000 "summarise this report"
+a2a send http://localhost:3000 "continue" --task-id task-abc --context-id ctx-1
+a2a send http://localhost:3000 "export" --accept-output text/plain --accept-output application/pdf
+```
+
+### `stream`
+
+Send a message and stream the response events. Each event is printed as it arrives.
+
+```sh
+a2a stream <AGENT_REF> <TEXT> [OPTIONS]
+```
+
+Accepts the same options as `send` except `--return-immediately`.
+
+```sh
+a2a stream http://localhost:3000 "write me a blog post"
+a2a -o json stream http://localhost:3000 "hello" --task-id task-abc
+```
+
+Use `-o json` to get one JSON object per line, which is convenient for piping to `jq`.
+
+### `task`
+
+Manage tasks on an agent.
+
+#### `task get`
+
+```sh
+a2a task get <AGENT_REF> <TASK_ID> [--history-length <N>]
+```
+
+#### `task list`
+
+```sh
+a2a task list <AGENT_REF> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--context-id <ID>` | Filter by context. |
+| `--status <STATE>` | Filter by state. Values: `submitted`, `working`, `completed`, `failed`, `canceled`, `input-required`, `rejected`, `auth-required`. |
+| `--page-size <N>` | Maximum number of tasks to return. |
+| `--page-token <TOKEN>` | Pagination cursor from a previous response. |
+| `--history-length <N>` | Number of history turns to include. |
+| `--include-artifacts` | Include task artifacts in the response. |
+
+```sh
+a2a task list http://localhost:3000
+a2a task list http://localhost:3000 --status completed --context-id ctx-1
+```
+
+#### `task cancel`
+
+```sh
+a2a task cancel <AGENT_REF> <TASK_ID>
+```
+
+#### `task subscribe`
+
+Stream live status-update events for a task until it reaches a terminal state.
+
+```sh
+a2a task subscribe <AGENT_REF> <TASK_ID>
+```
+
+```sh
+a2a -o json task subscribe http://localhost:3000 task-abc | jq '.statusUpdate.status.state'
+```
+
+### `push-config`
+
+Manage push notification configs for tasks.
+
+#### `push-config create`
+
+```sh
+a2a push-config create <AGENT_REF> <TASK_ID> <CALLBACK_URL> [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--config-id <ID>` | Assign a specific ID to the config (server-generated if omitted). |
+| `--token <TOKEN>` | Opaque token forwarded in push notifications. |
+| `--auth-scheme <SCHEME>` | Authentication scheme for the callback (e.g. `Bearer`). Requires `--auth-credentials`. |
+| `--auth-credentials <CREDS>` | Credentials for the callback endpoint. Requires `--auth-scheme`. |
+
+```sh
+a2a push-config create http://localhost:3000 task-abc https://my.service/webhook \
+  --config-id cfg-1 \
+  --auth-scheme Bearer \
+  --auth-credentials my-secret
+```
+
+#### `push-config get`
+
+```sh
+a2a push-config get <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+#### `push-config list`
+
+```sh
+a2a push-config list <AGENT_REF> <TASK_ID> [--page-size <N>] [--page-token <TOKEN>]
+```
+
+#### `push-config delete`
+
+```sh
+a2a push-config delete <AGENT_REF> <TASK_ID> <CONFIG_ID>
+```
+
+## Authentication
+
+### Bearer token
+
+```sh
+# via flag
+a2a --bearer-token my-token discover http://localhost:3000
+
+# via environment variable
+export A2A_BEARER_TOKEN=my-token
+a2a discover http://localhost:3000
+```
+
+### Custom headers
+
+```sh
+a2a --header "X-Api-Key: secret" --header "X-Tenant: acme" send http://localhost:3000 "hello"
+```
+
+## Output format
+
+By default responses are printed as indented (pretty-printed) JSON. Pass `-o json` for compact, one-object-per-line output.
+
+```sh
+# Pretty (default)
+a2a discover http://localhost:3000
+
+# Compact — pipe-friendly
+a2a -o json discover http://localhost:3000 | jq '.name'
+
+# Streaming compact — one event per line
+a2a -o json stream http://localhost:3000 "hello" | jq '.statusUpdate.status.state'
+```
+
+## Transport negotiation
+
+By default the CLI reads the agent card, discovers the supported interfaces, and picks a binding automatically (preferring JSON-RPC). Use `--enabled-binding` to restrict which binding is considered:
+
+```sh
+a2a --enabled-binding http-json send http://localhost:3000 "hello"
+a2a --enabled-binding jsonrpc   send http://localhost:3000 "hello"
+```
+
+`--enabled-binding` may be repeated; the CLI will use whichever of those bindings the agent card also advertises.

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -37,7 +37,11 @@ const CONFIG_FILENAME: &str = ".a2a.yaml";
 pub fn find_config_file() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let home = home_dir();
-    find_config_file_from(&cwd, home.as_deref())
+    find_config_file_from(&cwd, home.as_deref()).or_else(|| {
+        home.as_ref()
+            .map(|h| h.join(CONFIG_FILENAME))
+            .filter(|p| p.is_file())
+    })
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -129,8 +133,6 @@ fn parse_binding_str(s: &str) -> Option<Binding> {
     match s {
         "jsonrpc" => Some(Binding::Jsonrpc),
         "http-json" => Some(Binding::HttpJson),
-        #[cfg(feature = "slimrpc")]
-        "slimrpc" => Some(Binding::Slimrpc),
         _ => None,
     }
 }

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -1,0 +1,298 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::{Cli, HeaderArg, OutputFormat, Transport};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(default)]
+    pub transports: Vec<String>,
+    #[serde(default)]
+    pub bearer_token: Option<String>,
+    #[serde(default)]
+    pub headers: Vec<String>,
+    #[serde(default)]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read {0}: {1}")]
+    Io(PathBuf, std::io::Error),
+    #[error("failed to parse {0}: {1}")]
+    Parse(PathBuf, serde_yaml::Error),
+    #[error("invalid value in {0}: {1}")]
+    Invalid(PathBuf, String),
+}
+
+const CONFIG_FILENAME: &str = ".a2a.yaml";
+
+pub fn find_config_file() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let home = home_dir();
+    find_config_file_from(&cwd, home.as_deref())
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn find_config_file_from(start: &Path, home: Option<&Path>) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let candidate = dir.join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if home.is_some_and(|h| dir == h) {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => break,
+        }
+    }
+    None
+}
+
+pub fn load_config() -> Result<(Config, Option<PathBuf>), ConfigError> {
+    match find_config_file() {
+        Some(path) => {
+            let file = File::open(&path).map_err(|e| ConfigError::Io(path.clone(), e))?;
+            let config: Config = serde_yaml::from_reader(BufReader::new(file))
+                .map_err(|e| ConfigError::Parse(path.clone(), e))?;
+            Ok((config, Some(path)))
+        }
+        None => Ok((Config::default(), None)),
+    }
+}
+
+pub fn apply_config(
+    cli: &mut Cli,
+    config: &Config,
+    path: &Option<PathBuf>,
+) -> Result<(), ConfigError> {
+    let placeholder = PathBuf::from("<config>");
+    let p = path.as_ref().unwrap_or(&placeholder);
+
+    // Transports: CLI wins if any flags were given
+    if cli.transports.is_empty() && !config.transports.is_empty() {
+        for s in &config.transports {
+            let transport = parse_transport_str(s).ok_or_else(|| {
+                ConfigError::Invalid(p.clone(), format!("unknown transport: {s:?}"))
+            })?;
+            cli.transports.push(transport);
+        }
+    }
+
+    // Bearer token: CLI wins
+    if cli.bearer_token.is_none() {
+        cli.bearer_token = config.bearer_token.clone();
+    }
+
+    // Headers: additive — config headers first, then CLI headers
+    if !config.headers.is_empty() {
+        let mut config_headers: Vec<HeaderArg> = Vec::new();
+        for s in &config.headers {
+            let h = crate::parse_header(s).map_err(|e| {
+                ConfigError::Invalid(p.clone(), format!("invalid header {s:?}: {e}"))
+            })?;
+            config_headers.push(h);
+        }
+        config_headers.append(&mut cli.headers);
+        cli.headers = config_headers;
+    }
+
+    // Output: config only fills in if CLI didn't specify
+    if cli.output.is_none() {
+        if let Some(s) = &config.output {
+            let fmt = parse_output_format(s).ok_or_else(|| {
+                ConfigError::Invalid(p.clone(), format!("unknown output format: {s:?}"))
+            })?;
+            cli.output = Some(fmt);
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_transport_str(s: &str) -> Option<Transport> {
+    match s {
+        "jsonrpc" => Some(Transport::Jsonrpc),
+        "http-json" => Some(Transport::HttpJson),
+        #[cfg(feature = "slimrpc")]
+        "slimrpc" => Some(Transport::Slimrpc),
+        _ => None,
+    }
+}
+
+fn parse_output_format(s: &str) -> Option<OutputFormat> {
+    match s {
+        "pretty" => Some(OutputFormat::Pretty),
+        "json" => Some(OutputFormat::Json),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{OutputFormat, Transport};
+
+    fn parse_config(yaml: &str) -> Config {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    fn empty_cli() -> Cli {
+        use crate::Command;
+        Cli {
+            transports: vec![],
+            bearer_token: None,
+            headers: vec![],
+            output: None,
+            command: Command::Discover(crate::DiscoverCommand {
+                agent_ref: "http://localhost".to_string(),
+                extended: false,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_find_config_in_start_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+        assert_eq!(find_config_file_from(dir.path(), None), Some(cfg));
+    }
+
+    #[test]
+    fn test_find_config_walks_up() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = root.path().to_path_buf();
+        let child = parent.join("child");
+        std::fs::create_dir(&child).unwrap();
+
+        let cfg = parent.join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(find_config_file_from(&child, None), Some(cfg));
+    }
+
+    #[test]
+    fn test_find_config_stops_at_home() {
+        let home = tempfile::tempdir().unwrap();
+        let above = home.path().parent().unwrap().to_path_buf();
+        // Put config above home — should NOT be found
+        std::fs::write(above.join(".a2a.yaml"), "").unwrap();
+        assert_eq!(
+            find_config_file_from(home.path(), Some(home.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_config_found_at_home() {
+        let home = tempfile::tempdir().unwrap();
+        let cfg = home.path().join(".a2a.yaml");
+        std::fs::write(&cfg, "").unwrap();
+        assert_eq!(
+            find_config_file_from(home.path(), Some(home.path())),
+            Some(cfg)
+        );
+    }
+
+    #[test]
+    fn test_find_config_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(find_config_file_from(dir.path(), Some(dir.path())), None);
+    }
+
+    #[test]
+    fn test_parse_valid_config() {
+        let cfg = parse_config("transports:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
+        assert_eq!(cfg.transports, vec!["jsonrpc"]);
+        assert_eq!(cfg.bearer_token.as_deref(), Some("tok"));
+        assert_eq!(cfg.output.as_deref(), Some("json"));
+    }
+
+    #[test]
+    fn test_unknown_field_is_rejected() {
+        let result = serde_yaml::from_str::<Config>("typo_field: value");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_fills_empty_cli() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("transports:\n  - http-json\nbearer_token: tok\noutput: json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.transports, vec![crate::Transport::HttpJson]);
+        assert_eq!(cli.bearer_token.as_deref(), Some("tok"));
+        assert_eq!(cli.output, Some(OutputFormat::Json));
+    }
+
+    #[test]
+    fn test_cli_transports_take_precedence() {
+        let mut cli = empty_cli();
+        cli.transports = vec![Transport::Jsonrpc];
+        let cfg = parse_config("transports:\n  - http-json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.transports, vec![Transport::Jsonrpc]);
+    }
+
+    #[test]
+    fn test_headers_are_additive() {
+        let mut cli = empty_cli();
+        cli.headers = vec![HeaderArg {
+            name: "X-Cli".to_string(),
+            value: "cli".to_string(),
+        }];
+        let cfg = parse_config("headers:\n  - \"X-Config: cfg\"\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.headers.len(), 2);
+        assert_eq!(cli.headers[0].name, "X-Config");
+        assert_eq!(cli.headers[1].name, "X-Cli");
+    }
+
+    #[test]
+    fn test_invalid_transport_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("transports:\n  - bogus\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("unknown transport"));
+    }
+
+    #[test]
+    fn test_invalid_output_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("output: bogus\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("unknown output format"));
+    }
+
+    #[test]
+    fn test_invalid_header_errors() {
+        let mut cli = empty_cli();
+        let cfg = parse_config("headers:\n  - \"no-colon\"\n");
+        let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
+        assert!(err.to_string().contains("invalid header"));
+    }
+
+    #[test]
+    fn test_cli_output_takes_precedence() {
+        let mut cli = empty_cli();
+        cli.output = Some(OutputFormat::Pretty);
+        let cfg = parse_config("output: json\n");
+        apply_config(&mut cli, &cfg, &None).unwrap();
+        assert_eq!(cli.output, Some(OutputFormat::Pretty));
+    }
+}

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -7,13 +7,13 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::{Cli, HeaderArg, OutputFormat, Transport};
+use crate::{Binding, Cli, HeaderArg, OutputFormat};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
-    pub transports: Vec<String>,
+    pub enabled_bindings: Vec<String>,
     #[serde(default)]
     pub bearer_token: Option<String>,
     #[serde(default)]
@@ -84,13 +84,13 @@ pub fn apply_config(
     let placeholder = PathBuf::from("<config>");
     let p = path.as_ref().unwrap_or(&placeholder);
 
-    // Transports: CLI wins if any flags were given
-    if cli.transports.is_empty() && !config.transports.is_empty() {
-        for s in &config.transports {
-            let transport = parse_transport_str(s).ok_or_else(|| {
+    // Enabled bindings: CLI wins if any flags were given
+    if cli.enabled_bindings.is_empty() && !config.enabled_bindings.is_empty() {
+        for s in &config.enabled_bindings {
+            let binding = parse_binding_str(s).ok_or_else(|| {
                 ConfigError::Invalid(p.clone(), format!("unknown transport: {s:?}"))
             })?;
-            cli.transports.push(transport);
+            cli.enabled_bindings.push(binding);
         }
     }
 
@@ -125,12 +125,12 @@ pub fn apply_config(
     Ok(())
 }
 
-fn parse_transport_str(s: &str) -> Option<Transport> {
+fn parse_binding_str(s: &str) -> Option<Binding> {
     match s {
-        "jsonrpc" => Some(Transport::Jsonrpc),
-        "http-json" => Some(Transport::HttpJson),
+        "jsonrpc" => Some(Binding::Jsonrpc),
+        "http-json" => Some(Binding::HttpJson),
         #[cfg(feature = "slimrpc")]
-        "slimrpc" => Some(Transport::Slimrpc),
+        "slimrpc" => Some(Binding::Slimrpc),
         _ => None,
     }
 }
@@ -146,7 +146,7 @@ fn parse_output_format(s: &str) -> Option<OutputFormat> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{OutputFormat, Transport};
+    use crate::{Binding, OutputFormat};
 
     fn parse_config(yaml: &str) -> Config {
         serde_yaml::from_str(yaml).unwrap()
@@ -155,7 +155,7 @@ mod tests {
     fn empty_cli() -> Cli {
         use crate::Command;
         Cli {
-            transports: vec![],
+            enabled_bindings: vec![],
             bearer_token: None,
             headers: vec![],
             output: None,
@@ -218,8 +218,8 @@ mod tests {
 
     #[test]
     fn test_parse_valid_config() {
-        let cfg = parse_config("transports:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
-        assert_eq!(cfg.transports, vec!["jsonrpc"]);
+        let cfg = parse_config("enabled_bindings:\n  - jsonrpc\nbearer_token: tok\noutput: json\n");
+        assert_eq!(cfg.enabled_bindings, vec!["jsonrpc"]);
         assert_eq!(cfg.bearer_token.as_deref(), Some("tok"));
         assert_eq!(cfg.output.as_deref(), Some("json"));
     }
@@ -233,20 +233,20 @@ mod tests {
     #[test]
     fn test_apply_fills_empty_cli() {
         let mut cli = empty_cli();
-        let cfg = parse_config("transports:\n  - http-json\nbearer_token: tok\noutput: json\n");
+        let cfg = parse_config("enabled_bindings:\n  - http-json\nbearer_token: tok\noutput: json\n");
         apply_config(&mut cli, &cfg, &None).unwrap();
-        assert_eq!(cli.transports, vec![crate::Transport::HttpJson]);
+        assert_eq!(cli.enabled_bindings, vec![crate::Binding::HttpJson]);
         assert_eq!(cli.bearer_token.as_deref(), Some("tok"));
         assert_eq!(cli.output, Some(OutputFormat::Json));
     }
 
     #[test]
-    fn test_cli_transports_take_precedence() {
+    fn test_cli_bindings_take_precedence() {
         let mut cli = empty_cli();
-        cli.transports = vec![Transport::Jsonrpc];
-        let cfg = parse_config("transports:\n  - http-json\n");
+        cli.enabled_bindings = vec![Binding::Jsonrpc];
+        let cfg = parse_config("enabled_bindings:\n  - http-json\n");
         apply_config(&mut cli, &cfg, &None).unwrap();
-        assert_eq!(cli.transports, vec![Transport::Jsonrpc]);
+        assert_eq!(cli.enabled_bindings, vec![Binding::Jsonrpc]);
     }
 
     #[test]
@@ -264,9 +264,9 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_transport_errors() {
+    fn test_invalid_binding_errors() {
         let mut cli = empty_cli();
-        let cfg = parse_config("transports:\n  - bogus\n");
+        let cfg = parse_config("enabled_bindings:\n  - bogus\n");
         let err = apply_config(&mut cli, &cfg, &None).unwrap_err();
         assert!(err.to_string().contains("unknown transport"));
     }

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -1,6 +1,8 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(not(test))]
 use std::fs::File;
+#[cfg(not(test))]
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
@@ -34,6 +36,7 @@ pub enum ConfigError {
 
 const CONFIG_FILENAME: &str = ".a2a.yaml";
 
+#[cfg(not(test))]
 pub fn find_config_file() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let home = home_dir();
@@ -44,6 +47,7 @@ pub fn find_config_file() -> Option<PathBuf> {
     })
 }
 
+#[cfg(not(test))]
 fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
@@ -68,6 +72,7 @@ fn find_config_file_from(start: &Path, home: Option<&Path>) -> Option<PathBuf> {
     None
 }
 
+#[cfg(not(test))]
 pub fn load_config() -> Result<(Config, Option<PathBuf>), ConfigError> {
     match find_config_file() {
         Some(path) => {

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -138,6 +138,8 @@ fn parse_binding_str(s: &str) -> Option<Binding> {
     match s {
         "jsonrpc" => Some(Binding::Jsonrpc),
         "http-json" => Some(Binding::HttpJson),
+        #[cfg(feature = "slimrpc")]
+        "slimrpc" => Some(Binding::Slimrpc),
         _ => None,
     }
 }

--- a/a2acli/src/config.rs
+++ b/a2acli/src/config.rs
@@ -202,10 +202,7 @@ mod tests {
         let above = home.path().parent().unwrap().to_path_buf();
         // Put config above home — should NOT be found
         std::fs::write(above.join(".a2a.yaml"), "").unwrap();
-        assert_eq!(
-            find_config_file_from(home.path(), Some(home.path())),
-            None
-        );
+        assert_eq!(find_config_file_from(home.path(), Some(home.path())), None);
     }
 
     #[test]
@@ -242,7 +239,8 @@ mod tests {
     #[test]
     fn test_apply_fills_empty_cli() {
         let mut cli = empty_cli();
-        let cfg = parse_config("enabled_bindings:\n  - http-json\nbearer_token: tok\noutput: json\n");
+        let cfg =
+            parse_config("enabled_bindings:\n  - http-json\nbearer_token: tok\noutput: json\n");
         apply_config(&mut cli, &cfg, &None).unwrap();
         assert_eq!(cli.enabled_bindings, vec![crate::Binding::HttpJson]);
         assert_eq!(cli.bearer_token.as_deref(), Some("tok"));

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -12,15 +12,13 @@ use serde::Serialize;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Parser, PartialEq, Eq)]
-#[command(name = "a2acli", version, about = "Standalone A2A client CLI")]
+#[command(name = "a2a", version, about = "A2A client CLI")]
 pub struct Cli {
-    /// Base URL used to resolve /.well-known/agent-card.json.
-    #[arg(long, global = true, default_value = "http://localhost:3000")]
-    pub base_url: String,
-
-    /// Prefer a specific transport when the agent card exposes multiple bindings.
-    #[arg(long, global = true, value_enum)]
-    pub binding: Option<Binding>,
+    /// Enabled transports in preference order (first = most preferred).
+    /// Repeat the flag to enable multiple transports, e.g. --transport jsonrpc --transport http-json.
+    /// Only transports listed here will be used; the order overrides the server's preference.
+    #[arg(long = "transport", global = true, value_enum)]
+    pub transports: Vec<Transport>,
 
     /// Bearer token attached to the agent-card fetch and client calls.
     #[arg(long, global = true, env = "A2A_BEARER_TOKEN")]
@@ -34,32 +32,35 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub tenant: Option<String>,
 
-    /// Emit compact JSON instead of pretty-printed JSON.
-    #[arg(long, global = true)]
-    pub compact: bool,
+    /// Output format.
+    #[arg(long, short = 'o', global = true, value_enum, default_value = "pretty")]
+    pub output: OutputFormat,
 
     #[command(subcommand)]
     pub command: Command,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// Pretty-printed JSON.
+    Pretty,
+    /// Compact JSON (one object per line for streaming commands).
+    Json,
+}
+
 #[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
 pub enum Command {
-    /// Fetch and print the public agent card.
-    Card,
-    /// Fetch and print the extended agent card.
-    ExtendedCard,
-    /// Send a one-shot message.
-    Send(MessageCommand),
+    /// Fetch and print an agent's card.
+    Discover(DiscoverCommand),
+    /// Send a one-shot message to an agent.
+    Send(SendCommand),
     /// Send a streaming message and print each event as it arrives.
-    Stream(MessageCommand),
-    /// Fetch a task by ID.
-    GetTask(TaskLookupCommand),
-    /// List tasks with optional filters.
-    ListTasks(ListTasksCommand),
-    /// Cancel a task by ID.
-    CancelTask(TaskIdCommand),
-    /// Subscribe to task updates and print each event as it arrives.
-    Subscribe(TaskIdCommand),
+    Stream(StreamCommand),
+    /// Task lifecycle operations.
+    Task {
+        #[command(subcommand)]
+        command: TaskCommand,
+    },
     /// Manage push notification configs for a task.
     PushConfig {
         #[command(subcommand)]
@@ -68,7 +69,20 @@ pub enum Command {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct MessageCommand {
+pub struct DiscoverCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Fetch the extended agent card instead of the public one.
+    #[arg(long)]
+    pub extended: bool,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct SendCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Text payload to send as the user message.
     pub text: String,
 
@@ -94,7 +108,47 @@ pub struct MessageCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct TaskLookupCommand {
+pub struct StreamCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Text payload to send as the user message.
+    pub text: String,
+
+    /// Optional context identifier to continue an existing conversation.
+    #[arg(long)]
+    pub context_id: Option<String>,
+
+    /// Optional task identifier to continue an existing task.
+    #[arg(long)]
+    pub task_id: Option<String>,
+
+    /// Ask the server to include up to this many history items in task responses.
+    #[arg(long)]
+    pub history_length: Option<i32>,
+
+    /// Accepted output mode, for example text/plain or application/json.
+    #[arg(long = "accept-output")]
+    pub accepted_output_modes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
+pub enum TaskCommand {
+    /// Fetch a task by ID.
+    Get(TaskGetCommand),
+    /// List tasks with optional filters.
+    List(TaskListCommand),
+    /// Cancel a task by ID.
+    Cancel(TaskCancelCommand),
+    /// Subscribe to task updates and print each event as it arrives.
+    Subscribe(TaskSubscribeCommand),
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskGetCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub id: String,
 
@@ -104,7 +158,10 @@ pub struct TaskLookupCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct ListTasksCommand {
+pub struct TaskListCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Filter by context identifier.
     #[arg(long)]
     pub context_id: Option<String>,
@@ -131,7 +188,19 @@ pub struct ListTasksCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct TaskIdCommand {
+pub struct TaskCancelCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Task identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskSubscribeCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub id: String,
 }
@@ -141,15 +210,18 @@ pub enum PushConfigCommand {
     /// Create a push notification config for a task.
     Create(CreatePushConfigCommand),
     /// Fetch a push notification config by ID.
-    Get(PushConfigIdCommand),
+    Get(PushConfigGetCommand),
     /// List push notification configs for a task.
-    List(ListPushConfigsCommand),
+    List(PushConfigListCommand),
     /// Delete a push notification config by ID.
-    Delete(PushConfigIdCommand),
+    Delete(PushConfigDeleteCommand),
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 pub struct CreatePushConfigCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -174,7 +246,10 @@ pub struct CreatePushConfigCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct PushConfigIdCommand {
+pub struct PushConfigGetCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -183,7 +258,22 @@ pub struct PushConfigIdCommand {
 }
 
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
-pub struct ListPushConfigsCommand {
+pub struct PushConfigDeleteCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
+    /// Task identifier.
+    pub task_id: String,
+
+    /// Push config identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct PushConfigListCommand {
+    /// Agent reference: base URL, full agent-card URL, or local JSON file path.
+    pub agent_ref: String,
+
     /// Task identifier.
     pub task_id: String,
 
@@ -203,19 +293,21 @@ pub struct HeaderArg {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum Binding {
+pub enum Transport {
     Jsonrpc,
     HttpJson,
 }
 
-impl Binding {
+impl Transport {
     fn protocol(self) -> &'static str {
         match self {
-            Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
-            Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+            Transport::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
+            Transport::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
         }
     }
 }
+
+const DEFAULT_TRANSPORTS: &[Transport] = &[Transport::Jsonrpc, Transport::HttpJson];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum TaskStateArg {
@@ -254,102 +346,58 @@ pub enum CliError {
     Http(#[from] reqwest::Error),
     #[error("failed to serialize output: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("failed to read file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid agent card: {reason}")]
+    InvalidAgentCard { reason: String },
     #[error("invalid input: {0}")]
     InvalidInput(String),
 }
 
 pub async fn run(cli: Cli) -> Result<(), CliError> {
+    let compact = cli.output == OutputFormat::Json;
+
     match &cli.command {
-        Command::Card => {
-            let card = resolve_agent_card(&cli).await?;
-            print_json(&card, cli.compact)?;
-        }
-        Command::ExtendedCard => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .get_extended_agent_card(&GetExtendedAgentCardRequest {
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let card = finish_client_call(client, result).await?;
-            print_json(&card, cli.compact)?;
+        Command::Discover(command) => {
+            if command.extended {
+                let client = resolve_client(&command.agent_ref, &cli).await?;
+                let result = client
+                    .get_extended_agent_card(&GetExtendedAgentCardRequest {
+                        tenant: cli.tenant.clone(),
+                    })
+                    .await;
+                let card = finish_client_call(client, result).await?;
+                print_json(&card, compact)?;
+            } else {
+                let card = resolve_agent_card(&command.agent_ref, &cli).await?;
+                print_json(&card, compact)?;
+            }
         }
         Command::Send(command) => {
             let request = build_send_message_request(command, cli.tenant.clone());
-            let client = resolve_client(&cli).await?;
+            let client = resolve_client(&command.agent_ref, &cli).await?;
             let result = client.send_message(&request).await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         Command::Stream(command) => {
-            let client = resolve_client(&cli).await?;
-            let request = build_send_message_request(command, cli.tenant.clone());
+            let client = resolve_client(&command.agent_ref, &cli).await?;
+            let request = build_stream_message_request(command, cli.tenant.clone());
             let stream = client.send_streaming_message(&request).await?;
-            consume_stream(client, stream, cli.compact).await?;
+            consume_stream(client, stream, compact).await?;
         }
-        Command::GetTask(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .get_task(&GetTaskRequest {
-                    id: command.id.clone(),
-                    history_length: command.history_length,
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let task = finish_client_call(client, result).await?;
-            print_json(&task, cli.compact)?;
-        }
-        Command::ListTasks(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .list_tasks(&ListTasksRequest {
-                    context_id: command.context_id.clone(),
-                    status: command.status.map(TaskState::from),
-                    page_size: command.page_size,
-                    page_token: command.page_token.clone(),
-                    history_length: command.history_length,
-                    status_timestamp_after: None,
-                    include_artifacts: command.include_artifacts.then_some(true),
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
-        }
-        Command::CancelTask(command) => {
-            let client = resolve_client(&cli).await?;
-            let result = client
-                .cancel_task(&CancelTaskRequest {
-                    id: command.id.clone(),
-                    metadata: None,
-                    tenant: cli.tenant.clone(),
-                })
-                .await;
-            let task = finish_client_call(client, result).await?;
-            print_json(&task, cli.compact)?;
-        }
-        Command::Subscribe(command) => {
-            let client = resolve_client(&cli).await?;
-            let stream = client
-                .subscribe_to_task(&SubscribeToTaskRequest {
-                    id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
-                })
-                .await?;
-            consume_stream(client, stream, cli.compact).await?;
+        Command::Task { command } => {
+            run_task_command(&cli, command, compact).await?;
         }
         Command::PushConfig { command } => {
-            run_push_config_command(&cli, command).await?;
+            run_push_config_command(&cli, command, compact).await?;
         }
     }
 
     Ok(())
 }
 
-fn build_send_message_request(
-    command: &MessageCommand,
-    tenant: Option<String>,
-) -> SendMessageRequest {
+fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -375,6 +423,97 @@ fn build_send_message_request(
         metadata: None,
         tenant,
     }
+}
+
+fn build_stream_message_request(
+    command: &StreamCommand,
+    tenant: Option<String>,
+) -> SendMessageRequest {
+    let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
+    message.context_id = command.context_id.clone();
+    message.task_id = command.task_id.clone();
+
+    let configuration = if command.history_length.is_some()
+        || !command.accepted_output_modes.is_empty()
+    {
+        Some(SendMessageConfiguration {
+            accepted_output_modes: (!command.accepted_output_modes.is_empty())
+                .then_some(command.accepted_output_modes.clone()),
+            task_push_notification_config: None,
+            history_length: command.history_length,
+            return_immediately: None,
+        })
+    } else {
+        None
+    };
+
+    SendMessageRequest {
+        message,
+        configuration,
+        metadata: None,
+        tenant,
+    }
+}
+
+async fn run_task_command(
+    cli: &Cli,
+    command: &TaskCommand,
+    compact: bool,
+) -> Result<(), CliError> {
+    match command {
+        TaskCommand::Get(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .get_task(&GetTaskRequest {
+                    id: command.id.clone(),
+                    history_length: command.history_length,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, compact)?;
+        }
+        TaskCommand::List(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .list_tasks(&ListTasksRequest {
+                    context_id: command.context_id.clone(),
+                    status: command.status.map(TaskState::from),
+                    page_size: command.page_size,
+                    page_token: command.page_token.clone(),
+                    history_length: command.history_length,
+                    status_timestamp_after: None,
+                    include_artifacts: command.include_artifacts.then_some(true),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, compact)?;
+        }
+        TaskCommand::Cancel(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let result = client
+                .cancel_task(&CancelTaskRequest {
+                    id: command.id.clone(),
+                    metadata: None,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, compact)?;
+        }
+        TaskCommand::Subscribe(command) => {
+            let client = resolve_client(&command.agent_ref, cli).await?;
+            let stream = client
+                .subscribe_to_task(&SubscribeToTaskRequest {
+                    id: command.id.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await?;
+            consume_stream(client, stream, compact).await?;
+        }
+    }
+    Ok(())
 }
 
 fn build_push_notification_config(
@@ -404,19 +543,23 @@ fn build_push_notification_config(
     })
 }
 
-async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Result<(), CliError> {
+async fn run_push_config_command(
+    cli: &Cli,
+    command: &PushConfigCommand,
+    compact: bool,
+) -> Result<(), CliError> {
     match command {
         PushConfigCommand::Create(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
             config.tenant = cli.tenant.clone();
             let result = client.create_push_config(&config).await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::Get(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .get_push_config(&GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
@@ -425,10 +568,10 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::List(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .list_push_configs(&ListTaskPushNotificationConfigsRequest {
                     task_id: command.task_id.clone(),
@@ -438,10 +581,10 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
-            print_json(&response, cli.compact)?;
+            print_json(&response, compact)?;
         }
         PushConfigCommand::Delete(command) => {
-            let client = resolve_client(cli).await?;
+            let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
                 .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
@@ -456,7 +599,7 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
                     "taskId": command.task_id,
                     "id": command.id,
                 }),
-                cli.compact,
+                compact,
             )?;
         }
     }
@@ -464,13 +607,25 @@ async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Resu
     Ok(())
 }
 
-async fn resolve_client(cli: &Cli) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
-    let card = resolve_agent_card(cli).await?;
+async fn resolve_client(
+    agent_ref: &str,
+    cli: &Cli,
+) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
+    let card = resolve_agent_card(agent_ref, cli).await?;
 
-    let mut builder = A2AClientFactory::builder();
-    if let Some(binding) = cli.binding {
-        builder = builder.preferred_bindings(vec![binding.protocol().to_string()]);
-    }
+    let effective_transports = if cli.transports.is_empty() {
+        DEFAULT_TRANSPORTS.to_vec()
+    } else {
+        cli.transports.clone()
+    };
+
+    let preferred: Vec<String> = effective_transports
+        .iter()
+        .map(|t| t.protocol().to_string())
+        .collect();
+
+    let mut builder = A2AClientFactory::builder().preferred_bindings(preferred);
+
     if let Some(token) = &cli.bearer_token {
         builder = builder.with_interceptor(Arc::new(AuthInterceptor::bearer(token.clone())));
     }
@@ -485,15 +640,29 @@ async fn resolve_client(cli: &Cli) -> Result<A2AClient<Box<dyn a2a_client::Trans
     Ok(factory.create_from_card(&card).await?)
 }
 
-async fn resolve_agent_card(cli: &Cli) -> Result<AgentCard, CliError> {
-    let url = format!(
-        "{}/.well-known/agent-card.json",
-        cli.base_url.trim_end_matches('/')
-    );
-    let client = Client::new();
-    let request = apply_request_auth(client.get(url), cli);
-    let response = request.send().await?.error_for_status()?;
-    Ok(response.json::<AgentCard>().await?)
+async fn resolve_agent_card(agent_ref: &str, cli: &Cli) -> Result<AgentCard, CliError> {
+    if agent_ref.starts_with("http://") || agent_ref.starts_with("https://") {
+        let url = if agent_ref.ends_with(".json") {
+            agent_ref.to_string()
+        } else {
+            format!(
+                "{}/.well-known/agent-card.json",
+                agent_ref.trim_end_matches('/')
+            )
+        };
+        let client = Client::new();
+        let request = apply_request_auth(client.get(url), cli);
+        let response = request.send().await?.error_for_status()?;
+        let body = response.text().await?;
+        serde_json::from_str(&body).map_err(|e| CliError::InvalidAgentCard {
+            reason: e.to_string(),
+        })
+    } else {
+        let json = std::fs::read_to_string(agent_ref)?;
+        serde_json::from_str(&json).map_err(|e| CliError::InvalidAgentCard {
+            reason: e.to_string(),
+        })
+    }
 }
 
 fn apply_request_auth(mut request: RequestBuilder, cli: &Cli) -> RequestBuilder {
@@ -1096,12 +1265,8 @@ mod tests {
         }
     }
 
-    fn parse_cli_with_base_url(base_url: &str, args: &[&str]) -> Cli {
-        let mut argv = vec![
-            "a2acli".to_string(),
-            "--base-url".to_string(),
-            base_url.to_string(),
-        ];
+    fn parse_cli(args: &[&str]) -> Cli {
+        let mut argv = vec!["a2a".to_string()];
         argv.extend(args.iter().map(|arg| (*arg).to_string()));
         Cli::try_parse_from(argv).unwrap()
     }
@@ -1142,7 +1307,8 @@ mod tests {
     #[test]
     fn test_build_send_message_request_populates_optional_fields() {
         let request = build_send_message_request(
-            &MessageCommand {
+            &SendCommand {
+                agent_ref: "http://localhost:3000".to_string(),
                 text: "hello".to_string(),
                 context_id: Some("ctx-1".to_string()),
                 task_id: Some("task-1".to_string()),
@@ -1176,7 +1342,8 @@ mod tests {
     #[test]
     fn test_build_send_message_request_without_optional_fields() {
         let request = build_send_message_request(
-            &MessageCommand {
+            &SendCommand {
+                agent_ref: "http://localhost:3000".to_string(),
                 text: "hello".to_string(),
                 context_id: None,
                 task_id: None,
@@ -1194,30 +1361,29 @@ mod tests {
 
     #[test]
     fn test_cli_parse_send_command() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
-            "--binding",
+        let cli = parse_cli(&[
+            "--transport",
             "jsonrpc",
             "--header",
             "X-Test:123",
             "send",
+            "http://localhost:3000",
             "hello",
             "--history-length",
             "2",
-        ])
-        .unwrap();
+        ]);
 
-        assert_eq!(cli.binding, Some(Binding::Jsonrpc));
+        assert_eq!(cli.transports, vec![crate::Transport::Jsonrpc]);
         assert_eq!(cli.headers.len(), 1);
         assert!(matches!(cli.command, Command::Send(_)));
     }
 
     #[test]
     fn test_cli_parse_push_config_create_command() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
+        let cli = parse_cli(&[
             "push-config",
             "create",
+            "http://localhost:3000",
             "task-1",
             "https://example.com/callback",
             "--config-id",
@@ -1228,13 +1394,13 @@ mod tests {
             "Bearer",
             "--auth-credentials",
             "secret",
-        ])
-        .unwrap();
+        ]);
 
         match cli.command {
             Command::PushConfig {
                 command: PushConfigCommand::Create(command),
             } => {
+                assert_eq!(command.agent_ref, "http://localhost:3000");
                 assert_eq!(command.task_id, "task-1");
                 assert_eq!(command.url, "https://example.com/callback");
                 assert_eq!(command.config_id.as_deref(), Some("cfg-1"));
@@ -1249,6 +1415,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config() {
         let config = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: Some("cfg-1".to_string()),
@@ -1279,6 +1446,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config_requires_auth_scheme() {
         let err = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: None,
@@ -1294,6 +1462,7 @@ mod tests {
     #[test]
     fn test_build_push_notification_config_without_authentication() {
         let config = build_push_notification_config(&CreatePushConfigCommand {
+            agent_ref: "http://localhost:3000".to_string(),
             task_id: "task-1".to_string(),
             url: "https://example.com/callback".to_string(),
             config_id: None,
@@ -1308,22 +1477,21 @@ mod tests {
     }
 
     #[test]
-    fn test_binding_protocols() {
-        assert_eq!(Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
-        assert_eq!(Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+    fn test_transport_protocols() {
+        assert_eq!(crate::Transport::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
+        assert_eq!(crate::Transport::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
     }
 
     #[test]
     fn test_apply_request_auth_builds_headers() {
-        let cli = Cli::try_parse_from([
-            "a2acli",
+        let cli = parse_cli(&[
             "--bearer-token",
             "secret",
             "--header",
             "X-Test: 123",
-            "card",
-        ])
-        .unwrap();
+            "discover",
+            "http://localhost:3000",
+        ]);
 
         let request = apply_request_auth(Client::new().get("http://example.com"), &cli)
             .build()
@@ -1519,109 +1687,110 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_run_executes_all_commands_in_lib_tests() {
         let server = RunTestServer::spawn().await;
+        let base_url = &server.base_url;
 
-        run(parse_cli_with_base_url(&server.base_url, &["card"]))
+        run(parse_cli(&["discover", base_url])).await.unwrap();
+        run(parse_cli(&["-o", "json", "discover", base_url, "--extended"]))
             .await
             .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "extended-card"],
-        ))
+        run(parse_cli(&[
+            "--transport",
+            "jsonrpc",
+            "--bearer-token",
+            "secret",
+            "--header",
+            "X-Test: 123",
+            "send",
+            base_url,
+            "hello from unit test",
+            "--task-id",
+            "task-send",
+            "--context-id",
+            "ctx-send",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--binding",
-                "jsonrpc",
-                "--bearer-token",
-                "secret",
-                "--header",
-                "X-Test: 123",
-                "send",
-                "hello from unit test",
-                "--task-id",
-                "task-send",
-                "--context-id",
-                "ctx-send",
-            ],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "stream",
+            base_url,
+            "streaming request",
+            "--task-id",
+            "task-stream",
+            "--context-id",
+            "ctx-stream",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--compact",
-                "stream",
-                "streaming request",
-                "--task-id",
-                "task-stream",
-                "--context-id",
-                "ctx-stream",
-            ],
-        ))
+        run(parse_cli(&["task", "get", base_url, "task-send"]))
+            .await
+            .unwrap();
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "list",
+            base_url,
+            "--context-id",
+            "ctx-send",
+            "--status",
+            "completed",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["get-task", "task-send"],
-        ))
+        run(parse_cli(&["task", "cancel", base_url, "task-send"]))
+            .await
+            .unwrap();
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "subscribe",
+            base_url,
+            "task-stream",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "--compact",
-                "list-tasks",
-                "--context-id",
-                "ctx-send",
-                "--status",
-                "completed",
-            ],
-        ))
+        run(parse_cli(&[
+            "push-config",
+            "create",
+            base_url,
+            "task-1",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["cancel-task", "task-send"],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "push-config",
+            "get",
+            base_url,
+            "task-1",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "subscribe", "task-stream"],
-        ))
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "push-config",
+            "list",
+            base_url,
+            "task-1",
+        ]))
         .await
         .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "push-config",
-                "create",
-                "task-1",
-                "https://example.com/callback",
-                "--config-id",
-                "cfg-1",
-            ],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "push-config", "get", "task-1", "cfg-1"],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "push-config", "list", "task-1"],
-        ))
-        .await
-        .unwrap();
-        run(parse_cli_with_base_url(
-            &server.base_url,
-            &["push-config", "delete", "task-1", "cfg-1"],
-        ))
+        run(parse_cli(&[
+            "push-config",
+            "delete",
+            base_url,
+            "task-1",
+            "cfg-1",
+        ]))
         .await
         .unwrap();
     }
@@ -1629,33 +1798,31 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_run_surfaces_errors_in_lib_tests() {
         let server = RunTestServer::spawn().await;
+        let base_url = &server.base_url;
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["extended-card", "--tenant", "error"],
-        ))
-        .await
-        .unwrap_err();
+        let err = run(parse_cli(&["discover", base_url, "--extended", "--tenant", "error"]))
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::UNSUPPORTED_OPERATION
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["send", "send-error"],
-        ))
-        .await
-        .unwrap_err();
+        let err = run(parse_cli(&["send", base_url, "send-error"]))
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::INVALID_REQUEST
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["list-tasks", "--context-id", "error"],
-        ))
+        let err = run(parse_cli(&[
+            "task",
+            "list",
+            base_url,
+            "--context-id",
+            "error",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1663,10 +1830,22 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::INVALID_PARAMS
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "stream", "stream-error"],
-        ))
+        let err = run(parse_cli(&["-o", "json", "stream", base_url, "stream-error"]))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
+        ));
+
+        let err = run(parse_cli(&[
+            "-o",
+            "json",
+            "task",
+            "subscribe",
+            base_url,
+            "stream-error",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1674,28 +1853,15 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["--compact", "subscribe", "stream-error"],
-        ))
-        .await
-        .unwrap_err();
-        assert!(matches!(
-            err,
-            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
-        ));
-
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &[
-                "push-config",
-                "create",
-                "missing",
-                "https://example.com/callback",
-                "--config-id",
-                "cfg-missing",
-            ],
-        ))
+        let err = run(parse_cli(&[
+            "push-config",
+            "create",
+            base_url,
+            "missing",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-missing",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1703,10 +1869,12 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
         ));
 
-        let err = run(parse_cli_with_base_url(
-            &server.base_url,
-            &["push-config", "list", "missing"],
-        ))
+        let err = run(parse_cli(&[
+            "push-config",
+            "list",
+            base_url,
+            "missing",
+        ]))
         .await
         .unwrap_err();
         assert!(matches!(
@@ -1715,7 +1883,7 @@ mod tests {
         ));
 
         let base_url = unused_base_url().await;
-        let err = run(parse_cli_with_base_url(&base_url, &["card"]))
+        let err = run(parse_cli(&["discover", &base_url]))
             .await
             .unwrap_err();
         assert!(matches!(err, CliError::Http(_)));

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -305,6 +305,8 @@ impl Binding {
         match self {
             Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
             Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+            #[cfg(feature = "slimrpc")]
+            Binding::Slimrpc => a2a::TRANSPORT_PROTOCOL_SLIMRPC,
         }
     }
 }

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -631,6 +631,14 @@ async fn resolve_client(
 
     let mut builder = A2AClientFactory::builder().preferred_bindings(preferred);
 
+    #[cfg(feature = "slimrpc")]
+    if effective_bindings.contains(&Binding::Slimrpc) {
+        let slimrpc_factory = a2a_slimrpc::SlimRpcTransportFactory::from_slim_config()
+            .await
+            .map_err(CliError::A2A)?;
+        builder = builder.register(Arc::new(slimrpc_factory));
+    }
+
     if let Some(token) = &cli.bearer_token {
         builder = builder.with_interceptor(Arc::new(AuthInterceptor::bearer(token.clone())));
     }

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+mod config;
+
 use std::sync::Arc;
 
 use a2a::*;
@@ -28,13 +30,9 @@ pub struct Cli {
     #[arg(long = "header", global = true, value_parser = parse_header)]
     pub headers: Vec<HeaderArg>,
 
-    /// Optional tenant forwarded to A2A requests that support it.
-    #[arg(long, global = true)]
-    pub tenant: Option<String>,
-
-    /// Output format.
-    #[arg(long, short = 'o', global = true, value_enum, default_value = "pretty")]
-    pub output: OutputFormat,
+    /// Output format (default: pretty).
+    #[arg(long, short = 'o', global = true, value_enum)]
+    pub output: Option<OutputFormat>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -352,19 +350,21 @@ pub enum CliError {
     InvalidAgentCard { reason: String },
     #[error("invalid input: {0}")]
     InvalidInput(String),
+    #[error("{0}")]
+    Config(#[from] config::ConfigError),
 }
 
-pub async fn run(cli: Cli) -> Result<(), CliError> {
-    let compact = cli.output == OutputFormat::Json;
+pub async fn run(mut cli: Cli) -> Result<(), CliError> {
+    let (cfg, cfg_path) = config::load_config()?;
+    config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {
         Command::Discover(command) => {
             if command.extended {
                 let client = resolve_client(&command.agent_ref, &cli).await?;
                 let result = client
-                    .get_extended_agent_card(&GetExtendedAgentCardRequest {
-                        tenant: cli.tenant.clone(),
-                    })
+                    .get_extended_agent_card(&GetExtendedAgentCardRequest { tenant: None })
                     .await;
                 let card = finish_client_call(client, result).await?;
                 print_json(&card, compact)?;
@@ -374,7 +374,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
             }
         }
         Command::Send(command) => {
-            let request = build_send_message_request(command, cli.tenant.clone());
+            let request = build_send_message_request(command);
             let client = resolve_client(&command.agent_ref, &cli).await?;
             let result = client.send_message(&request).await;
             let response = finish_client_call(client, result).await?;
@@ -382,7 +382,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
         }
         Command::Stream(command) => {
             let client = resolve_client(&command.agent_ref, &cli).await?;
-            let request = build_stream_message_request(command, cli.tenant.clone());
+            let request = build_stream_message_request(command);
             let stream = client.send_streaming_message(&request).await?;
             consume_stream(client, stream, compact).await?;
         }
@@ -397,7 +397,7 @@ pub async fn run(cli: Cli) -> Result<(), CliError> {
     Ok(())
 }
 
-fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> SendMessageRequest {
+fn build_send_message_request(command: &SendCommand) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -421,14 +421,11 @@ fn build_send_message_request(command: &SendCommand, tenant: Option<String>) -> 
         message,
         configuration,
         metadata: None,
-        tenant,
+        tenant: None,
     }
 }
 
-fn build_stream_message_request(
-    command: &StreamCommand,
-    tenant: Option<String>,
-) -> SendMessageRequest {
+fn build_stream_message_request(command: &StreamCommand) -> SendMessageRequest {
     let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
@@ -451,7 +448,7 @@ fn build_stream_message_request(
         message,
         configuration,
         metadata: None,
-        tenant,
+        tenant: None,
     }
 }
 
@@ -467,7 +464,7 @@ async fn run_task_command(
                 .get_task(&GetTaskRequest {
                     id: command.id.clone(),
                     history_length: command.history_length,
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let task = finish_client_call(client, result).await?;
@@ -484,7 +481,7 @@ async fn run_task_command(
                     history_length: command.history_length,
                     status_timestamp_after: None,
                     include_artifacts: command.include_artifacts.then_some(true),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -496,7 +493,7 @@ async fn run_task_command(
                 .cancel_task(&CancelTaskRequest {
                     id: command.id.clone(),
                     metadata: None,
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let task = finish_client_call(client, result).await?;
@@ -507,7 +504,7 @@ async fn run_task_command(
             let stream = client
                 .subscribe_to_task(&SubscribeToTaskRequest {
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await?;
             consume_stream(client, stream, compact).await?;
@@ -553,7 +550,6 @@ async fn run_push_config_command(
             let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
-            config.tenant = cli.tenant.clone();
             let result = client.create_push_config(&config).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
@@ -564,7 +560,7 @@ async fn run_push_config_command(
                 .get_push_config(&GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -577,7 +573,7 @@ async fn run_push_config_command(
                     task_id: command.task_id.clone(),
                     page_size: command.page_size,
                     page_token: command.page_token.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             let response = finish_client_call(client, result).await?;
@@ -589,7 +585,7 @@ async fn run_push_config_command(
                 .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
-                    tenant: cli.tenant.clone(),
+                    tenant: None,
                 })
                 .await;
             finish_client_call(client, result).await?;
@@ -684,7 +680,7 @@ fn print_json<T: Serialize>(value: &T, compact: bool) -> Result<(), CliError> {
     Ok(())
 }
 
-fn parse_header(input: &str) -> Result<HeaderArg, String> {
+pub(crate) fn parse_header(input: &str) -> Result<HeaderArg, String> {
     let (name, value) = input
         .split_once(':')
         .ok_or_else(|| "header must be in NAME:VALUE format".to_string())?;
@@ -1204,12 +1200,8 @@ mod tests {
         async fn get_extended_agent_card(
             &self,
             _params: &HandlerServiceParams,
-            req: GetExtendedAgentCardRequest,
+            _req: GetExtendedAgentCardRequest,
         ) -> Result<AgentCard, A2AError> {
-            if req.tenant.as_deref() == Some("error") {
-                return Err(A2AError::unsupported_operation("extended card denied"));
-            }
-
             Ok(self.extended_card.clone())
         }
     }
@@ -1306,23 +1298,19 @@ mod tests {
 
     #[test]
     fn test_build_send_message_request_populates_optional_fields() {
-        let request = build_send_message_request(
-            &SendCommand {
-                agent_ref: "http://localhost:3000".to_string(),
-                text: "hello".to_string(),
-                context_id: Some("ctx-1".to_string()),
-                task_id: Some("task-1".to_string()),
-                history_length: Some(4),
-                accepted_output_modes: vec!["text/plain".to_string()],
-                return_immediately: true,
-            },
-            Some("tenant-1".to_string()),
-        );
+        let request = build_send_message_request(&SendCommand {
+            agent_ref: "http://localhost:3000".to_string(),
+            text: "hello".to_string(),
+            context_id: Some("ctx-1".to_string()),
+            task_id: Some("task-1".to_string()),
+            history_length: Some(4),
+            accepted_output_modes: vec!["text/plain".to_string()],
+            return_immediately: true,
+        });
 
         assert_eq!(request.message.text(), Some("hello"));
         assert_eq!(request.message.context_id.as_deref(), Some("ctx-1"));
         assert_eq!(request.message.task_id.as_deref(), Some("task-1"));
-        assert_eq!(request.tenant.as_deref(), Some("tenant-1"));
         assert_eq!(
             request
                 .configuration
@@ -1341,22 +1329,18 @@ mod tests {
 
     #[test]
     fn test_build_send_message_request_without_optional_fields() {
-        let request = build_send_message_request(
-            &SendCommand {
-                agent_ref: "http://localhost:3000".to_string(),
-                text: "hello".to_string(),
-                context_id: None,
-                task_id: None,
-                history_length: None,
-                accepted_output_modes: Vec::new(),
-                return_immediately: false,
-            },
-            None,
-        );
+        let request = build_send_message_request(&SendCommand {
+            agent_ref: "http://localhost:3000".to_string(),
+            text: "hello".to_string(),
+            context_id: None,
+            task_id: None,
+            history_length: None,
+            accepted_output_modes: Vec::new(),
+            return_immediately: false,
+        });
 
         assert_eq!(request.message.text(), Some("hello"));
         assert!(request.configuration.is_none());
-        assert!(request.tenant.is_none());
     }
 
     #[test]
@@ -1799,14 +1783,6 @@ mod tests {
     async fn test_run_surfaces_errors_in_lib_tests() {
         let server = RunTestServer::spawn().await;
         let base_url = &server.base_url;
-
-        let err = run(parse_cli(&["discover", base_url, "--extended", "--tenant", "error"]))
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            CliError::A2A(error) if error.code == a2a::error_code::UNSUPPORTED_OPERATION
-        ));
 
         let err = run(parse_cli(&["send", base_url, "send-error"]))
             .await

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -354,12 +354,14 @@ pub enum CliError {
     Config(#[from] config::ConfigError),
 }
 
-pub async fn run(mut cli: Cli) -> Result<(), CliError> {
+pub async fn run(cli: Cli) -> Result<(), CliError> {
     #[cfg(not(test))]
-    {
+    let cli = {
+        let mut cli = cli;
         let (cfg, cfg_path) = config::load_config()?;
         config::apply_config(&mut cli, &cfg, &cfg_path)?;
-    }
+        cli
+    };
     let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -16,11 +16,11 @@ use thiserror::Error;
 #[derive(Debug, Clone, Parser, PartialEq, Eq)]
 #[command(name = "a2a", version, about = "A2A client CLI")]
 pub struct Cli {
-    /// Enabled transports in preference order (first = most preferred).
-    /// Repeat the flag to enable multiple transports, e.g. --transport jsonrpc --transport http-json.
-    /// Only transports listed here will be used; the order overrides the server's preference.
-    #[arg(long = "transport", global = true, value_enum)]
-    pub transports: Vec<Transport>,
+    /// Enabled protocol bindings in preference order (first = most preferred).
+    /// Repeat the flag to enable multiple bindings, e.g. --enabled-binding jsonrpc --enabled-binding http-json.
+    /// Only bindings listed here will be used; the order overrides the server's preference.
+    #[arg(long = "enabled-binding", global = true, value_enum)]
+    pub enabled_bindings: Vec<Binding>,
 
     /// Bearer token attached to the agent-card fetch and client calls.
     #[arg(long, global = true, env = "A2A_BEARER_TOKEN")]
@@ -291,21 +291,21 @@ pub struct HeaderArg {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum Transport {
+pub enum Binding {
     Jsonrpc,
     HttpJson,
 }
 
-impl Transport {
+impl Binding {
     fn protocol(self) -> &'static str {
         match self {
-            Transport::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
-            Transport::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+            Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
+            Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
         }
     }
 }
 
-const DEFAULT_TRANSPORTS: &[Transport] = &[Transport::Jsonrpc, Transport::HttpJson];
+const DEFAULT_BINDINGS: &[Binding] = &[Binding::Jsonrpc, Binding::HttpJson];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum TaskStateArg {
@@ -609,15 +609,15 @@ async fn resolve_client(
 ) -> Result<A2AClient<Box<dyn a2a_client::Transport>>, CliError> {
     let card = resolve_agent_card(agent_ref, cli).await?;
 
-    let effective_transports = if cli.transports.is_empty() {
-        DEFAULT_TRANSPORTS.to_vec()
+    let effective_bindings = if cli.enabled_bindings.is_empty() {
+        DEFAULT_BINDINGS.to_vec()
     } else {
-        cli.transports.clone()
+        cli.enabled_bindings.clone()
     };
 
-    let preferred: Vec<String> = effective_transports
+    let preferred: Vec<String> = effective_bindings
         .iter()
-        .map(|t| t.protocol().to_string())
+        .map(|b| b.protocol().to_string())
         .collect();
 
     let mut builder = A2AClientFactory::builder().preferred_bindings(preferred);
@@ -1346,7 +1346,7 @@ mod tests {
     #[test]
     fn test_cli_parse_send_command() {
         let cli = parse_cli(&[
-            "--transport",
+            "--enabled-binding",
             "jsonrpc",
             "--header",
             "X-Test:123",
@@ -1357,7 +1357,7 @@ mod tests {
             "2",
         ]);
 
-        assert_eq!(cli.transports, vec![crate::Transport::Jsonrpc]);
+        assert_eq!(cli.enabled_bindings, vec![crate::Binding::Jsonrpc]);
         assert_eq!(cli.headers.len(), 1);
         assert!(matches!(cli.command, Command::Send(_)));
     }
@@ -1461,9 +1461,9 @@ mod tests {
     }
 
     #[test]
-    fn test_transport_protocols() {
-        assert_eq!(crate::Transport::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
-        assert_eq!(crate::Transport::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+    fn test_binding_protocols() {
+        assert_eq!(crate::Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
+        assert_eq!(crate::Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
     }
 
     #[test]
@@ -1678,7 +1678,7 @@ mod tests {
             .await
             .unwrap();
         run(parse_cli(&[
-            "--transport",
+            "--enabled-binding",
             "jsonrpc",
             "--bearer-token",
             "secret",

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -439,19 +439,18 @@ fn build_stream_message_request(command: &StreamCommand) -> SendMessageRequest {
     message.context_id = command.context_id.clone();
     message.task_id = command.task_id.clone();
 
-    let configuration = if command.history_length.is_some()
-        || !command.accepted_output_modes.is_empty()
-    {
-        Some(SendMessageConfiguration {
-            accepted_output_modes: (!command.accepted_output_modes.is_empty())
-                .then_some(command.accepted_output_modes.clone()),
-            task_push_notification_config: None,
-            history_length: command.history_length,
-            return_immediately: None,
-        })
-    } else {
-        None
-    };
+    let configuration =
+        if command.history_length.is_some() || !command.accepted_output_modes.is_empty() {
+            Some(SendMessageConfiguration {
+                accepted_output_modes: (!command.accepted_output_modes.is_empty())
+                    .then_some(command.accepted_output_modes.clone()),
+                task_push_notification_config: None,
+                history_length: command.history_length,
+                return_immediately: None,
+            })
+        } else {
+            None
+        };
 
     SendMessageRequest {
         message,
@@ -461,11 +460,7 @@ fn build_stream_message_request(command: &StreamCommand) -> SendMessageRequest {
     }
 }
 
-async fn run_task_command(
-    cli: &Cli,
-    command: &TaskCommand,
-    compact: bool,
-) -> Result<(), CliError> {
+async fn run_task_command(cli: &Cli, command: &TaskCommand, compact: bool) -> Result<(), CliError> {
     match command {
         TaskCommand::Get(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
@@ -633,7 +628,9 @@ async fn resolve_client(
 
     #[cfg(feature = "slimrpc")]
     if effective_bindings.contains(&Binding::Slimrpc) {
-        let slimrpc_factory = a2a_slimrpc::SlimRpcTransportFactory::from_slim_config()
+        let slimrpc_factory = a2a_slimrpc::SlimRpcTransportFactory::builder()
+            .with_slim_config()
+            .build()
             .await
             .map_err(CliError::A2A)?;
         builder = builder.register(Arc::new(slimrpc_factory));
@@ -1479,8 +1476,14 @@ mod tests {
 
     #[test]
     fn test_binding_protocols() {
-        assert_eq!(crate::Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
-        assert_eq!(crate::Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+        assert_eq!(
+            crate::Binding::Jsonrpc.protocol(),
+            TRANSPORT_PROTOCOL_JSONRPC
+        );
+        assert_eq!(
+            crate::Binding::HttpJson.protocol(),
+            TRANSPORT_PROTOCOL_HTTP_JSON
+        );
     }
 
     #[test]
@@ -1691,9 +1694,15 @@ mod tests {
         let base_url = &server.base_url;
 
         run(parse_cli(&["discover", base_url])).await.unwrap();
-        run(parse_cli(&["-o", "json", "discover", base_url, "--extended"]))
-            .await
-            .unwrap();
+        run(parse_cli(&[
+            "-o",
+            "json",
+            "discover",
+            base_url,
+            "--extended",
+        ]))
+        .await
+        .unwrap();
         run(parse_cli(&[
             "--enabled-binding",
             "jsonrpc",
@@ -1823,9 +1832,15 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::INVALID_PARAMS
         ));
 
-        let err = run(parse_cli(&["-o", "json", "stream", base_url, "stream-error"]))
-            .await
-            .unwrap_err();
+        let err = run(parse_cli(&[
+            "-o",
+            "json",
+            "stream",
+            base_url,
+            "stream-error",
+        ]))
+        .await
+        .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
@@ -1862,23 +1877,16 @@ mod tests {
             CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
         ));
 
-        let err = run(parse_cli(&[
-            "push-config",
-            "list",
-            base_url,
-            "missing",
-        ]))
-        .await
-        .unwrap_err();
+        let err = run(parse_cli(&["push-config", "list", base_url, "missing"]))
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
         ));
 
         let base_url = unused_base_url().await;
-        let err = run(parse_cli(&["discover", &base_url]))
-            .await
-            .unwrap_err();
+        let err = run(parse_cli(&["discover", &base_url])).await.unwrap_err();
         assert!(matches!(err, CliError::Http(_)));
     }
 

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -367,7 +367,7 @@ pub async fn run(mut cli: Cli) -> Result<(), CliError> {
             if command.extended {
                 let client = resolve_client(&command.agent_ref, &cli).await?;
                 let result = client
-                    .get_extended_agent_card(&GetExtendedAgentCardRequest { tenant: None })
+                    .get_extended_agent_card(GetExtendedAgentCardRequest { tenant: None })
                     .await;
                 let card = finish_client_call(client, result).await?;
                 print_json(&card, compact)?;
@@ -379,14 +379,14 @@ pub async fn run(mut cli: Cli) -> Result<(), CliError> {
         Command::Send(command) => {
             let request = build_send_message_request(command);
             let client = resolve_client(&command.agent_ref, &cli).await?;
-            let result = client.send_message(&request).await;
+            let result = client.send_message(request).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
         }
         Command::Stream(command) => {
             let client = resolve_client(&command.agent_ref, &cli).await?;
             let request = build_stream_message_request(command);
-            let stream = client.send_streaming_message(&request).await?;
+            let stream = client.send_streaming_message(request).await?;
             consume_stream(client, stream, compact).await?;
         }
         Command::Task { command } => {
@@ -464,7 +464,7 @@ async fn run_task_command(
         TaskCommand::Get(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .get_task(&GetTaskRequest {
+                .get_task(GetTaskRequest {
                     id: command.id.clone(),
                     history_length: command.history_length,
                     tenant: None,
@@ -476,7 +476,7 @@ async fn run_task_command(
         TaskCommand::List(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .list_tasks(&ListTasksRequest {
+                .list_tasks(ListTasksRequest {
                     context_id: command.context_id.clone(),
                     status: command.status.map(TaskState::from),
                     page_size: command.page_size,
@@ -493,7 +493,7 @@ async fn run_task_command(
         TaskCommand::Cancel(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .cancel_task(&CancelTaskRequest {
+                .cancel_task(CancelTaskRequest {
                     id: command.id.clone(),
                     metadata: None,
                     tenant: None,
@@ -505,7 +505,7 @@ async fn run_task_command(
         TaskCommand::Subscribe(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let stream = client
-                .subscribe_to_task(&SubscribeToTaskRequest {
+                .subscribe_to_task(SubscribeToTaskRequest {
                     id: command.id.clone(),
                     tenant: None,
                 })
@@ -553,14 +553,14 @@ async fn run_push_config_command(
             let client = resolve_client(&command.agent_ref, cli).await?;
             let mut config = build_push_notification_config(command)?;
             config.task_id = command.task_id.clone();
-            let result = client.create_push_config(&config).await;
+            let result = client.create_push_config(config).await;
             let response = finish_client_call(client, result).await?;
             print_json(&response, compact)?;
         }
         PushConfigCommand::Get(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .get_push_config(&GetTaskPushNotificationConfigRequest {
+                .get_push_config(GetTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
                     tenant: None,
@@ -572,7 +572,7 @@ async fn run_push_config_command(
         PushConfigCommand::List(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .list_push_configs(&ListTaskPushNotificationConfigsRequest {
+                .list_push_configs(ListTaskPushNotificationConfigsRequest {
                     task_id: command.task_id.clone(),
                     page_size: command.page_size,
                     page_token: command.page_token.clone(),
@@ -585,7 +585,7 @@ async fn run_push_config_command(
         PushConfigCommand::Delete(command) => {
             let client = resolve_client(&command.agent_ref, cli).await?;
             let result = client
-                .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
+                .delete_push_config(DeleteTaskPushNotificationConfigRequest {
                     task_id: command.task_id.clone(),
                     id: command.id.clone(),
                     tenant: None,
@@ -657,7 +657,7 @@ async fn resolve_agent_card(agent_ref: &str, cli: &Cli) -> Result<AgentCard, Cli
             reason: e.to_string(),
         })
     } else {
-        let json = std::fs::read_to_string(agent_ref)?;
+        let json = tokio::fs::read_to_string(agent_ref).await?;
         serde_json::from_str(&json).map_err(|e| CliError::InvalidAgentCard {
             reason: e.to_string(),
         })

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use a2a::*;
 use a2a_client::auth::AuthInterceptor;
 use a2a_client::{A2AClient, A2AClientFactory, BoxStream};
-#[cfg(feature = "slimrpc")]
-use a2a_slimrpc;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use futures::StreamExt;
 use reqwest::{Client, RequestBuilder};

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -355,8 +355,11 @@ pub enum CliError {
 }
 
 pub async fn run(mut cli: Cli) -> Result<(), CliError> {
-    let (cfg, cfg_path) = config::load_config()?;
-    config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    #[cfg(not(test))]
+    {
+        let (cfg, cfg_path) = config::load_config()?;
+        config::apply_config(&mut cli, &cfg, &cfg_path)?;
+    }
     let compact = cli.output.unwrap_or(OutputFormat::Pretty) == OutputFormat::Json;
 
     match &cli.command {

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use a2a::*;
 use a2a_client::auth::AuthInterceptor;
 use a2a_client::{A2AClient, A2AClientFactory, BoxStream};
+#[cfg(feature = "slimrpc")]
+use a2a_slimrpc;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use futures::StreamExt;
 use reqwest::{Client, RequestBuilder};
@@ -294,6 +296,8 @@ pub struct HeaderArg {
 pub enum Binding {
     Jsonrpc,
     HttpJson,
+    #[cfg(feature = "slimrpc")]
+    Slimrpc,
 }
 
 impl Binding {

--- a/a2acli/src/main.rs
+++ b/a2acli/src/main.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
+
     let cli = a2acli::Cli::parse();
     match a2acli::run(cli).await {
         Ok(()) => {}

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -367,12 +367,8 @@ impl RequestHandler for TestHandler {
     async fn get_extended_agent_card(
         &self,
         _params: &ServiceParams,
-        req: GetExtendedAgentCardRequest,
+        _req: GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
-        if req.tenant.as_deref() == Some("error") {
-            return Err(A2AError::unsupported_operation("extended card denied"));
-        }
-
         Ok(self.extended_card.clone())
     }
 }
@@ -585,8 +581,6 @@ async fn push_config_crud_commands_work() {
     let create = run_cli_success(&[
         "-o",
         "json",
-        "--tenant",
-        "tenant-1",
         "push-config",
         "create",
         base_url,
@@ -604,7 +598,6 @@ async fn push_config_crud_commands_work() {
     let create_json: Value = serde_json::from_str(create.trim()).unwrap();
     assert_eq!(create_json["taskId"], "task-1");
     assert_eq!(create_json["id"], "cfg-1");
-    assert_eq!(create_json["tenant"], "tenant-1");
 
     let get = run_cli_success(&[
         "-o",
@@ -660,15 +653,6 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("http request failed:"));
 
-    let (_stdout, stderr) = run_cli_failure(&[
-        "discover",
-        base_url,
-        "--extended",
-        "--tenant",
-        "error",
-    ]);
-    assert!(stderr.contains("a2a error -32004: extended card denied"));
-
     let (_stdout, stderr) = run_cli_failure(&["send", base_url, "send-error"]);
     assert!(stderr.contains("a2a error -32600: send failed"));
 
@@ -721,4 +705,27 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
         "secret",
     ]);
     assert!(stderr.contains("invalid input: --auth-credentials requires --auth-scheme"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_file_sets_output_format() {
+    let server = TestServer::spawn().await;
+    let base_url = &server.base_url;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".a2a.yaml"), "output: json\n").unwrap();
+
+    let output = StdCommand::cargo_bin("a2a")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["discover", base_url])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    // compact JSON (output: json) is a single line; pretty-printed JSON spans multiple lines
+    assert_eq!(stdout.trim().lines().count(), 1);
 }

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -478,7 +478,7 @@ async fn card_and_extended_card_commands_work() {
     assert_eq!(headers[0].1.as_deref(), Some("abc"));
 
     let compact = run_cli_success(&[
-        "--transport",
+        "--enabled-binding",
         "http-json",
         "-o",
         "json",

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -428,17 +428,15 @@ fn make_task(task_id: &str, context_id: &str, state: TaskState, text: &str) -> T
     }
 }
 
-fn run_cli_success(server: &TestServer, args: &[&str]) -> String {
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
-    command.args(["--base-url", server.base_url.as_str()]);
+fn run_cli_success(args: &[&str]) -> String {
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     command.args(args);
     let output = command.assert().success().get_output().stdout.clone();
     String::from_utf8(output).unwrap()
 }
 
-fn run_cli_failure(server: &TestServer, args: &[&str]) -> (String, String) {
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
-    command.args(["--base-url", server.base_url.as_str()]);
+fn run_cli_failure(args: &[&str]) -> (String, String) {
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     command.args(args);
     let output = command.assert().failure().get_output().clone();
     (
@@ -465,17 +463,16 @@ async fn unused_base_url() -> String {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn card_and_extended_card_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let stdout = run_cli_success(
-        &server,
-        &[
-            "--bearer-token",
-            "secret",
-            "--header",
-            "X-Test: abc",
-            "card",
-        ],
-    );
+    let stdout = run_cli_success(&[
+        "--bearer-token",
+        "secret",
+        "--header",
+        "X-Test: abc",
+        "discover",
+        base_url,
+    ]);
     let card: Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(card["name"], "Fixture Agent");
 
@@ -484,10 +481,15 @@ async fn card_and_extended_card_commands_work() {
     assert_eq!(headers[0].0.as_deref(), Some("Bearer secret"));
     assert_eq!(headers[0].1.as_deref(), Some("abc"));
 
-    let compact = run_cli_success(
-        &server,
-        &["--binding", "http-json", "--compact", "extended-card"],
-    );
+    let compact = run_cli_success(&[
+        "--transport",
+        "http-json",
+        "-o",
+        "json",
+        "discover",
+        base_url,
+        "--extended",
+    ]);
     assert!(!compact.trim_end().contains('\n'));
     let card: Value = serde_json::from_str(compact.trim()).unwrap();
     assert_eq!(card["name"], "Fixture Agent (extended)");
@@ -496,25 +498,24 @@ async fn card_and_extended_card_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn send_task_list_and_cancel_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let send = run_cli_success(
-        &server,
-        &[
-            "--bearer-token",
-            "secret",
-            "--header",
-            "X-Trace: 123",
-            "send",
-            "hello from cli",
-            "--task-id",
-            "task-send",
-            "--context-id",
-            "ctx-send",
-            "--accept-output",
-            "text/plain",
-            "--return-immediately",
-        ],
-    );
+    let send = run_cli_success(&[
+        "--bearer-token",
+        "secret",
+        "--header",
+        "X-Trace: 123",
+        "send",
+        base_url,
+        "hello from cli",
+        "--task-id",
+        "task-send",
+        "--context-id",
+        "ctx-send",
+        "--accept-output",
+        "text/plain",
+        "--return-immediately",
+    ]);
     let send_json: Value = serde_json::from_str(&send).unwrap();
     assert_eq!(send_json["task"]["id"], "task-send");
     assert_eq!(
@@ -522,25 +523,25 @@ async fn send_task_list_and_cancel_commands_work() {
         "Echo: hello from cli"
     );
 
-    let get_task = run_cli_success(&server, &["get-task", "task-send", "--history-length", "1"]);
+    let get_task = run_cli_success(&["task", "get", base_url, "task-send", "--history-length", "1"]);
     let task_json: Value = serde_json::from_str(&get_task).unwrap();
     assert_eq!(task_json["id"], "task-send");
 
-    let list = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "list-tasks",
-            "--context-id",
-            "ctx-send",
-            "--status",
-            "completed",
-        ],
-    );
+    let list = run_cli_success(&[
+        "-o",
+        "json",
+        "task",
+        "list",
+        base_url,
+        "--context-id",
+        "ctx-send",
+        "--status",
+        "completed",
+    ]);
     let list_json: Value = serde_json::from_str(list.trim()).unwrap();
     assert_eq!(list_json["tasks"].as_array().unwrap().len(), 1);
 
-    let cancel = run_cli_success(&server, &["cancel-task", "task-send"]);
+    let cancel = run_cli_success(&["task", "cancel", base_url, "task-send"]);
     let cancel_json: Value = serde_json::from_str(&cancel).unwrap();
     assert_eq!(cancel_json["status"]["state"], "TASK_STATE_CANCELED");
 }
@@ -548,19 +549,19 @@ async fn send_task_list_and_cancel_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stream_and_subscribe_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let stream_output = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "stream",
-            "streaming request",
-            "--task-id",
-            "task-stream",
-            "--context-id",
-            "ctx-stream",
-        ],
-    );
+    let stream_output = run_cli_success(&[
+        "-o",
+        "json",
+        "stream",
+        base_url,
+        "streaming request",
+        "--task-id",
+        "task-stream",
+        "--context-id",
+        "ctx-stream",
+    ]);
     let stream_events = parse_json_lines(&stream_output);
     assert_eq!(stream_events.len(), 2);
     assert_eq!(
@@ -569,7 +570,8 @@ async fn stream_and_subscribe_commands_work() {
     );
     assert_eq!(stream_events[1]["task"]["id"], "task-stream");
 
-    let subscribe_output = run_cli_success(&server, &["--compact", "subscribe", "task-stream"]);
+    let subscribe_output =
+        run_cli_success(&["-o", "json", "task", "subscribe", base_url, "task-stream"]);
     let subscribe_events = parse_json_lines(&subscribe_output);
     assert_eq!(subscribe_events.len(), 2);
     assert_eq!(subscribe_events[1]["task"]["id"], "task-stream");
@@ -578,57 +580,66 @@ async fn stream_and_subscribe_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn push_config_crud_commands_work() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let create = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "--tenant",
-            "tenant-1",
-            "push-config",
-            "create",
-            "task-1",
-            "https://example.com/callback",
-            "--config-id",
-            "cfg-1",
-            "--token",
-            "tok-1",
-            "--auth-scheme",
-            "Bearer",
-            "--auth-credentials",
-            "secret",
-        ],
-    );
+    let create = run_cli_success(&[
+        "-o",
+        "json",
+        "--tenant",
+        "tenant-1",
+        "push-config",
+        "create",
+        base_url,
+        "task-1",
+        "https://example.com/callback",
+        "--config-id",
+        "cfg-1",
+        "--token",
+        "tok-1",
+        "--auth-scheme",
+        "Bearer",
+        "--auth-credentials",
+        "secret",
+    ]);
     let create_json: Value = serde_json::from_str(create.trim()).unwrap();
     assert_eq!(create_json["taskId"], "task-1");
     assert_eq!(create_json["id"], "cfg-1");
     assert_eq!(create_json["tenant"], "tenant-1");
 
-    let get = run_cli_success(
-        &server,
-        &["--compact", "push-config", "get", "task-1", "cfg-1"],
-    );
+    let get = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "get",
+        base_url,
+        "task-1",
+        "cfg-1",
+    ]);
     let get_json: Value = serde_json::from_str(get.trim()).unwrap();
     assert_eq!(get_json["authentication"]["scheme"], "Bearer");
 
-    let list = run_cli_success(
-        &server,
-        &[
-            "--compact",
-            "push-config",
-            "list",
-            "task-1",
-            "--page-size",
-            "10",
-        ],
-    );
+    let list = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "list",
+        base_url,
+        "task-1",
+        "--page-size",
+        "10",
+    ]);
     let list_json: Value = serde_json::from_str(list.trim()).unwrap();
     assert_eq!(list_json["configs"].as_array().unwrap().len(), 1);
 
-    let delete = run_cli_success(
-        &server,
-        &["--compact", "push-config", "delete", "task-1", "cfg-1"],
-    );
+    let delete = run_cli_success(&[
+        "-o",
+        "json",
+        "push-config",
+        "delete",
+        base_url,
+        "task-1",
+        "cfg-1",
+    ]);
     let delete_json: Value = serde_json::from_str(delete.trim()).unwrap();
     assert_eq!(delete_json["deleted"], true);
 }
@@ -636,11 +647,12 @@ async fn push_config_crud_commands_work() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn binary_reports_a2a_and_non_a2a_errors() {
     let server = TestServer::spawn().await;
+    let base_url = server.base_url.as_str();
 
-    let base_url = unused_base_url().await;
-    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
+    let unreachable_url = unused_base_url().await;
+    let mut command = StdCommand::cargo_bin("a2a").unwrap();
     let output = command
-        .args(["--base-url", base_url.as_str(), "card"])
+        .args(["discover", unreachable_url.as_str()])
         .assert()
         .failure()
         .get_output()
@@ -648,60 +660,65 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("http request failed:"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["extended-card", "--tenant", "error"]);
+    let (_stdout, stderr) = run_cli_failure(&[
+        "discover",
+        base_url,
+        "--extended",
+        "--tenant",
+        "error",
+    ]);
     assert!(stderr.contains("a2a error -32004: extended card denied"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["send", "send-error"]);
+    let (_stdout, stderr) = run_cli_failure(&["send", base_url, "send-error"]);
     assert!(stderr.contains("a2a error -32600: send failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["list-tasks", "--context-id", "error"]);
+    let (_stdout, stderr) =
+        run_cli_failure(&["task", "list", base_url, "--context-id", "error"]);
     assert!(stderr.contains("a2a error -32602: list failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["get-task", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "get", base_url, "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["cancel-task", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "cancel", base_url, "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["subscribe", "stream-error"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "subscribe", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
-    let (_stdout, stderr) = run_cli_failure(&server, &["--compact", "stream", "stream-error"]);
+    let (_stdout, stderr) =
+        run_cli_failure(&["-o", "json", "stream", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
-    let (_stdout, stderr) = run_cli_failure(
-        &server,
-        &[
-            "push-config",
-            "create",
-            "missing",
-            "https://example.com/callback",
-            "--config-id",
-            "cfg-missing",
-        ],
-    );
-    assert!(stderr.contains("a2a error -32001: task not found: missing"));
-
-    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "get", "task-1", "missing"]);
-    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
-
-    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "list", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&[
+        "push-config",
+        "create",
+        base_url,
+        "missing",
+        "https://example.com/callback",
+        "--config-id",
+        "cfg-missing",
+    ]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
     let (_stdout, stderr) =
-        run_cli_failure(&server, &["push-config", "delete", "task-1", "missing"]);
+        run_cli_failure(&["push-config", "get", base_url, "task-1", "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: task-1"));
 
-    let (_stdout, stderr) = run_cli_failure(
-        &server,
-        &[
-            "push-config",
-            "create",
-            "task-1",
-            "https://example.com/callback",
-            "--auth-credentials",
-            "secret",
-        ],
-    );
+    let (_stdout, stderr) = run_cli_failure(&["push-config", "list", base_url, "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) =
+        run_cli_failure(&["push-config", "delete", base_url, "task-1", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
+
+    let (_stdout, stderr) = run_cli_failure(&[
+        "push-config",
+        "create",
+        base_url,
+        "task-1",
+        "https://example.com/callback",
+        "--auth-credentials",
+        "secret",
+    ]);
     assert!(stderr.contains("invalid input: --auth-credentials requires --auth-scheme"));
 }

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -519,7 +519,14 @@ async fn send_task_list_and_cancel_commands_work() {
         "Echo: hello from cli"
     );
 
-    let get_task = run_cli_success(&["task", "get", base_url, "task-send", "--history-length", "1"]);
+    let get_task = run_cli_success(&[
+        "task",
+        "get",
+        base_url,
+        "task-send",
+        "--history-length",
+        "1",
+    ]);
     let task_json: Value = serde_json::from_str(&get_task).unwrap();
     assert_eq!(task_json["id"], "task-send");
 
@@ -656,8 +663,7 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let (_stdout, stderr) = run_cli_failure(&["send", base_url, "send-error"]);
     assert!(stderr.contains("a2a error -32600: send failed"));
 
-    let (_stdout, stderr) =
-        run_cli_failure(&["task", "list", base_url, "--context-id", "error"]);
+    let (_stdout, stderr) = run_cli_failure(&["task", "list", base_url, "--context-id", "error"]);
     assert!(stderr.contains("a2a error -32602: list failed"));
 
     let (_stdout, stderr) = run_cli_failure(&["task", "get", base_url, "missing"]);
@@ -669,8 +675,7 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     let (_stdout, stderr) = run_cli_failure(&["task", "subscribe", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
-    let (_stdout, stderr) =
-        run_cli_failure(&["-o", "json", "stream", base_url, "stream-error"]);
+    let (_stdout, stderr) = run_cli_failure(&["-o", "json", "stream", base_url, "stream-error"]);
     assert!(stderr.contains("a2a error -32603: stream failed"));
 
     let (_stdout, stderr) = run_cli_failure(&[
@@ -684,8 +689,7 @@ async fn binary_reports_a2a_and_non_a2a_errors() {
     ]);
     assert!(stderr.contains("a2a error -32001: task not found: missing"));
 
-    let (_stdout, stderr) =
-        run_cli_failure(&["push-config", "get", base_url, "task-1", "missing"]);
+    let (_stdout, stderr) = run_cli_failure(&["push-config", "get", base_url, "task-1", "missing"]);
     assert!(stderr.contains("a2a error -32001: task not found: task-1"));
 
     let (_stdout, stderr) = run_cli_failure(&["push-config", "list", base_url, "missing"]);

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -254,7 +254,7 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
     println!("{sep}");
 
     // ---- send_message ----------------------------------------------------
-    let task_id = match client.send_message(&req("Hello, world!")).await {
+    let task_id = match client.send_message(req("Hello, world!")).await {
         Ok(SendMessageResponse::Task(t)) => {
             row!("send_message", &t.id, &t.status.state);
             t.id
@@ -271,7 +271,7 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
 
     // ---- get_task --------------------------------------------------------
     match client
-        .get_task(&GetTaskRequest {
+        .get_task(GetTaskRequest {
             id: task_id.clone(),
             history_length: Some(10),
             tenant: None,
@@ -284,7 +284,7 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
 
     // ---- list_tasks ------------------------------------------------------
     match client
-        .list_tasks(&ListTasksRequest {
+        .list_tasks(ListTasksRequest {
             context_id: None,
             status: None,
             page_size: Some(10),
@@ -301,10 +301,10 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
     }
 
     // ---- cancel_task -----------------------------------------------------
-    match client.send_message(&wait_req("cancel demo")).await {
+    match client.send_message(wait_req("cancel demo")).await {
         Ok(SendMessageResponse::Task(t)) => {
             match client
-                .cancel_task(&CancelTaskRequest {
+                .cancel_task(CancelTaskRequest {
                     id: t.id,
                     metadata: None,
                     tenant: None,
@@ -326,7 +326,7 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
         metadata: None,
         tenant: None,
     };
-    match client.send_streaming_message(&stream_req).await {
+    match client.send_streaming_message(stream_req).await {
         Ok(mut stream) => {
             println!("send_streaming_message");
             let mut n = 0usize;
@@ -349,11 +349,11 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
     }
 
     // ---- subscribe_to_task -----------------------------------------------
-    match client.send_message(&wait_req("subscribe demo")).await {
+    match client.send_message(wait_req("subscribe demo")).await {
         Ok(SendMessageResponse::Task(t)) => {
             let sub_id = t.id;
             match client
-                .subscribe_to_task(&SubscribeToTaskRequest {
+                .subscribe_to_task(SubscribeToTaskRequest {
                     id: sub_id.clone(),
                     tenant: None,
                 })
@@ -361,7 +361,7 @@ pub async fn exercise_client<T: Transport>(protocol: &str, client: &A2AClient<T>
             {
                 Ok(mut sub) => {
                     match client
-                        .cancel_task(&CancelTaskRequest {
+                        .cancel_task(CancelTaskRequest {
                             id: sub_id.clone(),
                             metadata: None,
                             tenant: None,


### PR DESCRIPTION
## Summary

Adds SlimRPC as an opt-in transport in the \`a2a\` CLI, building on the transport/config redesign in #101.

### Changes

**\`a2acli\` SlimRPC integration**
- New \`slimrpc\` Cargo feature on \`a2acli\`; gates \`Binding::Slimrpc\` variant in the CLI enum
- \`--enabled-binding slimrpc\` is accepted when the feature is enabled
- \`SlimRpcTransportFactory\` is registered with \`A2AClientFactory\` when \`--enabled-binding slimrpc\` is requested, so SLIMRPC transports are actually dispatched instead of falling through to JSONRPC

**\`a2a-slimrpc\` config discovery and connection ID**
- \`SlimRpcTransportFactory::from_slim_config\` and \`SlimRpcTransport::from_slim_config\` now call \`create_app_from_slim_config_async\` and propagate the returned \`conn_id\` via \`new_with_connection\`
- \`slim.yaml\` is discovered walking up from the current working directory (falling back to \`~/.slim/config.yaml\`), with environment variables taking highest priority

**Transport binding observability**
- \`A2AClientFactory::create_from_card\` now emits \`info\`-level tracing for candidate bindings, each attempt, and the selected binding

## Depends on

PR #101 (\`feat/cli-redesign-1929\`) — this branch is stacked on top of it.