### PR TITLE
fix(server): harden push notifications (URL validation, CRLF credentials, per-task config cap)

### DIFF
--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -997,8 +997,16 @@ mod tests {
     }
 
     fn make_push_delivery_handler() -> DefaultRequestHandler {
+        // URL validation is disabled because the test webhook runs on
+        // 127.0.0.1; the default HttpPushSender rejects loopback targets.
         DefaultRequestHandler::new(PushEventExecutor, InMemoryTaskStore::new())
-            .with_push_config_store(InMemoryPushConfigStore::new())
+            .with_push_notifications(
+                InMemoryPushConfigStore::new(),
+                crate::HttpPushSender::new(Some(crate::HttpPushSenderConfig {
+                    validate_urls: false,
+                    ..Default::default()
+                })),
+            )
     }
 
     fn make_resumable_handler() -> (DefaultRequestHandler, Arc<Notify>) {

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -17,7 +17,7 @@ pub use agent_card::{AgentCardProducer, StaticAgentCard, WELL_KNOWN_AGENT_CARD_P
 pub use executor::{AgentExecutor, ExecutorContext};
 pub use handler::{DefaultRequestHandler, RequestHandler};
 pub use middleware::{CallContext, CallInterceptor, InterceptedHandler, ServiceParams, User};
-pub use push::{HttpPushSender, InMemoryPushConfigStore, PushConfigStore};
+pub use push::{HttpPushSender, HttpPushSenderConfig, InMemoryPushConfigStore, PushConfigStore};
 pub use task_store::{InMemoryTaskStore, TaskStore};
 
 #[cfg(test)]

--- a/a2a-server/src/push/mod.rs
+++ b/a2a-server/src/push/mod.rs
@@ -3,5 +3,5 @@
 mod sender;
 mod store;
 
-pub use sender::HttpPushSender;
+pub use sender::{HttpPushSender, HttpPushSenderConfig};
 pub use store::{InMemoryPushConfigStore, PushConfigStore};

--- a/a2a-server/src/push/sender.rs
+++ b/a2a-server/src/push/sender.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 pub struct HttpPushSender {
     client: reqwest::Client,
     fail_on_error: bool,
+    validate_urls: bool,
 }
 
 /// Configuration for [`HttpPushSender`].
@@ -17,6 +18,11 @@ pub struct HttpPushSenderConfig {
     pub timeout: Duration,
     /// If true, push sending errors abort execution.
     pub fail_on_error: bool,
+    /// If true (default), reject push URLs that target loopback, private,
+    /// link-local, multicast, unspecified, or cloud-metadata addresses, and
+    /// URLs whose scheme is not http/https. Disable only when pushing to
+    /// local webhooks in trusted test environments.
+    pub validate_urls: bool,
 }
 
 impl Default for HttpPushSenderConfig {
@@ -24,6 +30,7 @@ impl Default for HttpPushSenderConfig {
         HttpPushSenderConfig {
             timeout: Duration::from_secs(30),
             fail_on_error: false,
+            validate_urls: true,
         }
     }
 }
@@ -38,6 +45,7 @@ impl HttpPushSender {
         HttpPushSender {
             client,
             fail_on_error: config.fail_on_error,
+            validate_urls: config.validate_urls,
         }
     }
 
@@ -47,6 +55,29 @@ impl HttpPushSender {
         config: &TaskPushNotificationConfig,
         event: StreamResponse,
     ) -> Result<(), A2AError> {
+        if self.validate_urls {
+            validate_push_url(&config.url)?;
+        }
+
+        // Reject credentials containing CR/LF so they cannot inject
+        // additional headers into the outgoing request (BUG-34).
+        if let Some(ref token) = config.token {
+            if token.contains('\r') || token.contains('\n') {
+                return Err(A2AError::invalid_params(
+                    "push notification token must not contain CR/LF",
+                ));
+            }
+        }
+        if let Some(ref auth) = config.authentication {
+            if let Some(ref creds) = auth.credentials {
+                if creds.contains('\r') || creds.contains('\n') {
+                    return Err(A2AError::invalid_params(
+                        "push credentials must not contain CR/LF",
+                    ));
+                }
+            }
+        }
+
         let body = match serde_json::to_vec(&event) {
             Ok(b) => b,
             Err(e) => return self.handle_error(format!("failed to serialize event: {e}")),
@@ -98,6 +129,69 @@ impl HttpPushSender {
     }
 }
 
+/// Validate a push notification URL against SSRF targets (BUG-54).
+///
+/// The URL scheme must be http/https and the host must not resolve to a
+/// loopback, private, link-local, multicast, or unspecified address, nor to a
+/// well-known cloud metadata endpoint.
+fn validate_push_url(url: &str) -> Result<(), A2AError> {
+    let parsed =
+        reqwest::Url::parse(url).map_err(|_| A2AError::invalid_params("invalid push notification URL"))?;
+
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(A2AError::invalid_params(
+            "push URL must be http or https",
+        ));
+    }
+
+    if let Some(host) = parsed.host_str() {
+        // Block well-known loopback, metadata, and unspecified hosts.
+        let blocked = [
+            "127.0.0.1",
+            "localhost",
+            "::1",
+            "[::1]",
+            "169.254.169.254",
+            "metadata.google.internal",
+            "metadata.azure.com",
+            "metadata.goog",
+            "0.0.0.0",
+        ];
+        if blocked.contains(&host) {
+            return Err(A2AError::invalid_params("push URL targets blocked host"));
+        }
+        // Block IP literals in restricted ranges (loopback, RFC 1918
+        // private, link-local, ULA, unspecified, multicast).
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            let blocked = match ip {
+                std::net::IpAddr::V4(v4) => {
+                    v4.is_loopback()
+                        || v4.is_private()
+                        || v4.is_link_local()
+                        || v4.is_unspecified()
+                        || v4.is_multicast()
+                }
+                std::net::IpAddr::V6(v6) => {
+                    // fc00::/7 unique local addresses (IPv6 "private").
+                    let is_ula = (v6.segments()[0] & 0xfe00) == 0xfc00;
+                    v6.is_loopback()
+                        || is_ula
+                        || v6.is_unicast_link_local()
+                        || v6.is_unspecified()
+                        || v6.is_multicast()
+                }
+            };
+            if blocked {
+                return Err(A2AError::invalid_params(
+                    "push URL targets private/loopback/link-local address",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,6 +203,7 @@ mod tests {
         let config = HttpPushSenderConfig::default();
         assert_eq!(config.timeout, Duration::from_secs(30));
         assert!(!config.fail_on_error);
+        assert!(config.validate_urls);
     }
 
     #[test]
@@ -116,6 +211,7 @@ mod tests {
         install_crypto_provider();
         let sender = HttpPushSender::new(None);
         assert!(!sender.fail_on_error);
+        assert!(sender.validate_urls);
     }
 
     #[test]
@@ -124,9 +220,11 @@ mod tests {
         let config = HttpPushSenderConfig {
             timeout: Duration::from_secs(10),
             fail_on_error: true,
+            validate_urls: false,
         };
         let sender = HttpPushSender::new(Some(config));
         assert!(sender.fail_on_error);
+        assert!(!sender.validate_urls);
     }
 
     #[test]
@@ -135,6 +233,7 @@ mod tests {
         let sender = HttpPushSender::new(Some(HttpPushSenderConfig {
             timeout: Duration::from_secs(5),
             fail_on_error: true,
+            validate_urls: true,
         }));
         let result = sender.handle_error("test error".to_string());
         assert!(result.is_err());
@@ -148,11 +247,38 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    fn sample_status_update() -> StreamResponse {
+        use a2a::event::*;
+        StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+            task_id: "t1".into(),
+            context_id: "c1".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            metadata: None,
+        })
+    }
+
+    fn sample_config(url: &str) -> TaskPushNotificationConfig {
+        TaskPushNotificationConfig {
+            task_id: String::new(),
+            url: url.to_string(),
+            id: None,
+            token: None,
+            authentication: None,
+            tenant: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_send_push_connection_refused_no_fail() {
-        use a2a::event::*;
         install_crypto_provider();
-        let sender = HttpPushSender::new(None);
+        let sender = HttpPushSender::new(Some(HttpPushSenderConfig {
+            validate_urls: false,
+            ..Default::default()
+        }));
         let config = TaskPushNotificationConfig {
             task_id: String::new(),
             url: "http://127.0.0.1:1/callback".to_string(),
@@ -164,56 +290,31 @@ mod tests {
             }),
             tenant: None,
         };
-        let event = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
-            task_id: "t1".into(),
-            context_id: "c1".into(),
-            status: TaskStatus {
-                state: TaskState::Working,
-                message: None,
-                timestamp: None,
-            },
-            metadata: None,
-        });
-        let result = sender.send_push(&config, event).await;
+        let result = sender.send_push(&config, sample_status_update()).await;
         // Should be Ok because fail_on_error is false
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn test_send_push_connection_refused_fail() {
-        use a2a::event::*;
         install_crypto_provider();
         let sender = HttpPushSender::new(Some(HttpPushSenderConfig {
             timeout: std::time::Duration::from_millis(100),
             fail_on_error: true,
+            validate_urls: false,
         }));
-        let config = TaskPushNotificationConfig {
-            task_id: String::new(),
-            url: "http://127.0.0.1:1/callback".to_string(),
-            id: None,
-            token: None,
-            authentication: None,
-            tenant: None,
-        };
-        let event = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
-            task_id: "t1".into(),
-            context_id: "c1".into(),
-            status: TaskStatus {
-                state: TaskState::Working,
-                message: None,
-                timestamp: None,
-            },
-            metadata: None,
-        });
-        let result = sender.send_push(&config, event).await;
+        let config = sample_config("http://127.0.0.1:1/callback");
+        let result = sender.send_push(&config, sample_status_update()).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_send_push_with_basic_auth() {
-        use a2a::event::*;
         install_crypto_provider();
-        let sender = HttpPushSender::new(None);
+        let sender = HttpPushSender::new(Some(HttpPushSenderConfig {
+            validate_urls: false,
+            ..Default::default()
+        }));
         let config = TaskPushNotificationConfig {
             task_id: String::new(),
             url: "http://127.0.0.1:1/callback".to_string(),
@@ -225,26 +326,18 @@ mod tests {
             }),
             tenant: None,
         };
-        let event = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
-            task_id: "t1".into(),
-            context_id: "c1".into(),
-            status: TaskStatus {
-                state: TaskState::Working,
-                message: None,
-                timestamp: None,
-            },
-            metadata: None,
-        });
+        let result = sender.send_push(&config, sample_status_update()).await;
         // Will fail to connect but exercises basic auth header path
-        let result = sender.send_push(&config, event).await;
         assert!(result.is_ok()); // fail_on_error=false
     }
 
     #[tokio::test]
     async fn test_send_push_with_unknown_auth_scheme() {
-        use a2a::event::*;
         install_crypto_provider();
-        let sender = HttpPushSender::new(None);
+        let sender = HttpPushSender::new(Some(HttpPushSenderConfig {
+            validate_urls: false,
+            ..Default::default()
+        }));
         let config = TaskPushNotificationConfig {
             task_id: String::new(),
             url: "http://127.0.0.1:1/callback".to_string(),
@@ -256,17 +349,109 @@ mod tests {
             }),
             tenant: None,
         };
-        let event = StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
-            task_id: "t1".into(),
-            context_id: "c1".into(),
-            status: TaskStatus {
-                state: TaskState::Working,
-                message: None,
-                timestamp: None,
-            },
-            metadata: None,
-        });
-        let result = sender.send_push(&config, event).await;
+        let result = sender.send_push(&config, sample_status_update()).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_push_url_rejects_non_http_schemes() {
+        for url in ["file:///etc/passwd", "ftp://example.com/hook", "gopher://example.com/"] {
+            let err = validate_push_url(url).unwrap_err();
+            assert_eq!(err.code, error_code::INVALID_PARAMS);
+        }
+    }
+
+    #[test]
+    fn test_validate_push_url_rejects_loopback() {
+        for url in [
+            "http://127.0.0.1:1/callback",
+            "http://localhost/callback",
+            "http://[::1]/callback",
+            "http://0.0.0.0/callback",
+        ] {
+            assert!(
+                validate_push_url(url).is_err(),
+                "expected {url} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_push_url_rejects_private_and_link_local() {
+        for url in [
+            "http://10.0.0.1/callback",
+            "http://192.168.1.1/callback",
+            "http://172.16.0.1/callback",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://169.254.1.1/callback",
+            "http://metadata.google.internal/callback",
+        ] {
+            assert!(
+                validate_push_url(url).is_err(),
+                "expected {url} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_push_url_accepts_public_urls() {
+        for url in [
+            "http://example.com/callback",
+            "https://example.com/callback",
+            "https://hooks.example.com/abc?x=1",
+        ] {
+            assert!(
+                validate_push_url(url).is_ok(),
+                "expected {url} to be accepted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_push_rejects_blocked_url_even_without_fail_on_error() {
+        install_crypto_provider();
+        let sender = HttpPushSender::new(None); // validate_urls = true
+        let config = sample_config("http://127.0.0.1:1/callback");
+        let result = sender.send_push(&config, sample_status_update()).await;
+        // Validation errors are always returned, regardless of fail_on_error.
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn test_send_push_rejects_crlf_credentials() {
+        install_crypto_provider();
+        let sender = HttpPushSender::new(None);
+        let config = TaskPushNotificationConfig {
+            task_id: String::new(),
+            url: "https://example.com/callback".to_string(),
+            id: None,
+            token: None,
+            authentication: Some(AuthenticationInfo {
+                scheme: "bearer".to_string(),
+                credentials: Some("secret\r\nX-Injected: 1".to_string()),
+            }),
+            tenant: None,
+        };
+        let result = sender.send_push(&config, sample_status_update()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn test_send_push_rejects_crlf_token() {
+        install_crypto_provider();
+        let sender = HttpPushSender::new(None);
+        let config = TaskPushNotificationConfig {
+            task_id: String::new(),
+            url: "https://example.com/callback".to_string(),
+            id: None,
+            token: Some("tok\nX-Injected: 1".to_string()),
+            authentication: None,
+            tenant: None,
+        };
+        let result = sender.send_push(&config, sample_status_update()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::INVALID_PARAMS);
     }
 }

--- a/a2a-server/src/push/store.rs
+++ b/a2a-server/src/push/store.rs
@@ -5,10 +5,12 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 
+/// Maximum number of push notification configs allowed per task (BUG-42).
+const MAX_PUSH_CONFIGS_PER_TASK: usize = 50;
+
 /// Interface for persisting push notification configurations.
 #[async_trait]
-pub trait PushConfigStore: Send + Sync + 'static {
-    /// Save a push config for a task. Generates an ID if none provided.
+pub trait PushConfigStore: Send + Sync + 'static {    /// Save a push config for a task. Generates an ID if none provided.
     async fn save(
         &self,
         config: TaskPushNotificationConfig,
@@ -72,6 +74,16 @@ impl PushConfigStore for InMemoryPushConfigStore {
         let mut store = self.configs.write().await;
         let task_configs = store.entry(config.task_id.clone()).or_default();
         let config_id = config.id.clone().unwrap();
+        // Enforce a per-task cap so a client cannot register unbounded
+        // configs, each consuming memory and triggering outbound requests.
+        // Replacing an existing config by ID is still allowed at the cap.
+        if !task_configs.contains_key(&config_id)
+            && task_configs.len() >= MAX_PUSH_CONFIGS_PER_TASK
+        {
+            return Err(A2AError::invalid_params(format!(
+                "too many push notification configs for task (max {MAX_PUSH_CONFIGS_PER_TASK})"
+            )));
+        }
         task_configs.insert(config_id, config.clone());
         Ok(config)
     }
@@ -227,5 +239,52 @@ mod tests {
         store.delete_all("t1").await.unwrap();
         let configs = store.list("t1").await.unwrap();
         assert_eq!(configs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_save_caps_configs_per_task() {
+        let store = InMemoryPushConfigStore::new();
+        for i in 0..MAX_PUSH_CONFIGS_PER_TASK {
+            store
+                .save(make_config("t1", &format!("https://example.com/hook/{i}")))
+                .await
+                .unwrap();
+        }
+
+        // The (cap + 1)-th distinct config is rejected.
+        let result = store
+            .save(make_config("t1", "https://example.com/over-limit"))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::INVALID_PARAMS);
+
+        // Other tasks are not affected.
+        store
+            .save(make_config("t2", "https://example.com/hook"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_save_can_replace_existing_config_at_cap() {
+        let store = InMemoryPushConfigStore::new();
+        let mut first = make_config("t1", "https://example.com/hook/0");
+        first.id = Some("cfg-keep".to_string());
+        store.save(first).await.unwrap();
+        for i in 1..MAX_PUSH_CONFIGS_PER_TASK {
+            store
+                .save(make_config("t1", &format!("https://example.com/hook/{i}")))
+                .await
+                .unwrap();
+        }
+        assert_eq!(store.list("t1").await.unwrap().len(), MAX_PUSH_CONFIGS_PER_TASK);
+
+        // Updating an existing config by ID is allowed even at the cap.
+        let mut config = make_config("t1", "https://example.com/replaced");
+        config.id = Some("cfg-keep".to_string());
+        let saved = store.save(config).await.unwrap();
+        assert_eq!(saved.id.as_deref(), Some("cfg-keep"));
+        assert_eq!(saved.url, "https://example.com/replaced");
+        assert_eq!(store.list("t1").await.unwrap().len(), MAX_PUSH_CONFIGS_PER_TASK);
     }
 }

--- a/examples/tests/transports_e2e.rs
+++ b/examples/tests/transports_e2e.rs
@@ -12,8 +12,9 @@ use a2a_client::rest::RestTransport;
 use a2a_server::jsonrpc::jsonrpc_router;
 use a2a_server::rest::rest_router;
 use a2a_server::{
-    DefaultRequestHandler, ExecutorContext, HttpPushSender, InMemoryPushConfigStore,
-    InMemoryTaskStore, RequestHandler, ServiceParams, WELL_KNOWN_AGENT_CARD_PATH,
+    DefaultRequestHandler, ExecutorContext, HttpPushSender, HttpPushSenderConfig,
+    InMemoryPushConfigStore, InMemoryTaskStore, RequestHandler, ServiceParams,
+    WELL_KNOWN_AGENT_CARD_PATH,
 };
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -338,9 +339,18 @@ async fn spawn_http_server() -> (String, tokio::task::JoinHandle<()>) {
 }
 
 async fn spawn_push_http_server() -> (String, tokio::task::JoinHandle<()>) {
+    // URL validation is disabled here because the e2e webhook runs on
+    // 127.0.0.1; the default HttpPushSender rejects loopback targets (SSRF
+    // guard, see push/sender.rs validate_push_url).
     let handler = Arc::new(
         DefaultRequestHandler::new(PushTransportExecutor, InMemoryTaskStore::new())
-            .with_push_notifications(InMemoryPushConfigStore::new(), HttpPushSender::new(None)),
+            .with_push_notifications(
+                InMemoryPushConfigStore::new(),
+                HttpPushSender::new(Some(HttpPushSenderConfig {
+                    validate_urls: false,
+                    ..Default::default()
+                })),
+            ),
     );
     let app = Router::new()
         .nest("/rest", rest_router(handler.clone()))


### PR DESCRIPTION
## What changed

### 1. SSRF protection for push notification URLs 

**Problem:** `send_push` POSTed to whatever URL a client supplied in `TaskPushNotificationConfig` with no scheme/host/IP validation. A malicious client could point the server at `http://127.0.0.1`, `http://169.254.169.254` (cloud metadata), or any internal service (CWE-918). Go fixed this with an `ssrfGuardedTransport` + `isBlockedIP`; Python and JS fixed it via PR. Rust had no protection.

**Fix (a2a-server/src/push/sender.rs):**
- Added `validate_push_url(url)` invoked at the start of `send_push`: the scheme must be `http`/`https`; well-known loopback/metadata hosts (`127.0.0.1`, `localhost`, `::1`, `169.254.169.254`, `metadata.google.internal`, `metadata.azure.com`, `metadata.goog`, `0.0.0.0`) are blocked; IP literals in loopback, RFC 1918 private, link-local, IPv6 ULA (`fc00::/7`), unspecified, or multicast ranges are blocked.
- Added `HttpPushSenderConfig::validate_urls` (default `true` — secure by default). Disable only for trusted local webhooks; the flag is exposed for test environments.

### 2. Reject CR/LF in push credentials and tokens 

**Problem:** `Authorization` / `A2A-Notification-Token` headers were built by string concatenation, so credentials or tokens containing CR/LF could inject additional headers into the outgoing push request (header injection). `reqwest` rejects such values, but the error was opaque.

**Fix (a2a-server/src/push/sender.rs):**
- `send_push` now rejects credentials or notification tokens containing `\r` or `\n` with an explicit `INVALID_PARAMS` error before building the request.

### 3. Per-task push notification config limit 

**Problem:** `InMemoryPushConfigStore::save` accepted an unlimited number of configs per task; each config consumes memory and triggers an outbound HTTP request on every event, so a client could register unbounded configs (resource exhaustion).

**Fix (a2a-server/src/push/store.rs):**
- `InMemoryPushConfigStore::save` now enforces a cap of 50 configs per task (`MAX_PUSH_CONFIGS_PER_TASK`); exceeding it returns `INVALID_PARAMS`. Replacing an existing config by ID is still allowed at the cap.
- `HttpPushSenderConfig` is now exported from `a2a_server` (`lib.rs`, `push/mod.rs`) so consumers can construct senders with explicit configuration.

### 4. Test adaptation for the new URL validation

**Problem:** Existing tests deliver pushes to a webhook on `127.0.0.1`, which the new SSRF guard rejects.

**Fix (a2a-server/src/handler.rs tests, examples/tests/transports_e2e.rs):**
- `handler::tests::make_push_delivery_handler` and the e2e `spawn_push_http_server` now build the sender with `validate_urls: false`, explicitly opting out of URL validation for local test webhooks. The default `HttpPushSender::new(None)` keeps validation enabled.
- The connection-refused and auth-header tests in `push/sender.rs` now use `validate_urls: false` so they still exercise the HTTP path; the validation logic itself is covered by new dedicated tests.

## Testing

- `cargo test -p a2a-server-lf`: **135 passed, 0 failed** (+ 1 doc-test passed).
- New regression tests:
 - `push::sender::tests::test_validate_push_url_rejects_non_http_schemes`
 - `push::sender::tests::test_validate_push_url_rejects_loopback`
 - `push::sender::tests::test_validate_push_url_rejects_private_and_link_local`
 - `push::sender::tests::test_validate_push_url_accepts_public_urls`
 - `push::sender::tests::test_send_push_rejects_blocked_url_even_without_fail_on_error`
 - `push::sender::tests::test_send_push_rejects_crlf_credentials`
 - `push::sender::tests::test_send_push_rejects_crlf_token`
 - `push::store::tests::test_save_caps_configs_per_task`
 - `push::store::tests::test_save_can_replace_existing_config_at_cap`
- Behavior change: by default (`HttpPushSender::new(None)` / `HttpPushSenderConfig::default()`) push URLs targeting loopback/private/link-local/metadata addresses are now rejected with `INVALID_PARAMS`, and configs beyond 50 per task are rejected. Existing tests that pushed to `127.0.0.1` webhooks were adapted as described above.
- Note: `examples` / `a2a-grpc` / `a2a-slimrpc` packages cannot be compiled in this environment (missing NASM for `aws-lc-sys`, missing `protoc`) — pre-existing environment limitation, unrelated to this change.

