### PR TITLE
fix(server): add SSE event ids and keep-alive, enforce request body size limit

### DIFF
--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -6,7 +6,7 @@ use a2a::*;
 use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
 use axum::{
     Json,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
@@ -38,6 +38,9 @@ pub fn jsonrpc_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
     let state = JsonRpcState { handler };
     axum::Router::new()
         .route("/", axum::routing::post(handle_jsonrpc::<H>))
+        // Cap the request body size at 10 MB instead of relying on the
+        // framework's implicit default (BUG-60).
+        .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .with_state(state)
 }
 
@@ -344,6 +347,31 @@ mod tests {
         let result =
             protojson_conv::from_value::<SendMessageResponse>(resp.result.unwrap()).unwrap();
         assert!(matches!(result, SendMessageResponse::Task(_)));
+    }
+
+    #[tokio::test]
+    async fn test_send_message_body_over_limit_rejected() {
+        let app = make_app();
+        let body = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "x".repeat(11 * 1024 * 1024)}]
+            }
+        });
+        let rpc = JsonRpcRequest::new(
+            JsonRpcId::Number(1),
+            methods::SEND_MESSAGE,
+            Some(body),
+        );
+        let req = Request::builder()
+            .uri("/")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&rpc).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[tokio::test]

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -6,7 +6,7 @@ use a2a::*;
 use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{DefaultBodyLimit, Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
@@ -115,6 +115,9 @@ pub fn rest_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
             REST_EXTENDED_AGENT_CARD_LEGACY_PATH,
             axum::routing::get(handle_get_extended_agent_card::<H>),
         )
+        // Cap the request body size at 10 MB instead of relying on the
+        // framework's implicit default (BUG-60).
+        .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .with_state(state)
 }
 
@@ -594,6 +597,27 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_body_over_limit_rejected() {
+        let app = make_app();
+        let body = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "x".repeat(11 * 1024 * 1024)}]
+            }
+        });
+        let body = serde_json::to_string(&body).unwrap();
+        let req = Request::builder()
+            .uri(REST_SEND_MESSAGE_PATH)
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[tokio::test]

--- a/a2a-server/src/sse.rs
+++ b/a2a-server/src/sse.rs
@@ -1,36 +1,49 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
-use axum::response::sse::{Event, Sse};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use std::convert::Infallible;
+use std::time::Duration;
 
 /// Convert a boxed stream of serializable items into an SSE response.
+///
+/// Each event carries a monotonic, counter-based `id` so clients can resume
+/// interrupted subscriptions, and the response sends a keep-alive comment
+/// frame every 15 seconds so intermediaries do not terminate idle
+/// connections (BUG-57).
 pub fn sse_from_stream<T: serde::Serialize + Send + 'static>(
     stream: BoxStream<'static, Result<T, a2a::A2AError>>,
 ) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
-    let sse_stream = stream.map(|item| {
+    let mut counter = 0u64;
+    let sse_stream = stream.map(move |item| {
+        counter += 1;
         let event = match item {
             Ok(val) => {
                 let data = serde_json::to_string(&val).unwrap_or_default();
-                Event::default().data(data)
+                Event::default().id(counter.to_string()).data(data)
             }
             Err(err) => {
                 let error_json = serde_json::to_string(&err.to_jsonrpc_error()).unwrap_or_default();
-                Event::default().data(error_json)
+                Event::default().id(counter.to_string()).data(error_json)
             }
         };
         Ok::<_, Infallible>(event)
     });
-    Sse::new(sse_stream)
+    Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 
 /// Convert a boxed stream of JSON-RPC responses into an SSE response.
+///
+/// Each event carries a monotonic, counter-based `id` and the response sends
+/// a keep-alive comment frame every 15 seconds (BUG-57).
 pub fn sse_jsonrpc_stream<T: serde::Serialize + Send + 'static>(
     request_id: a2a::JsonRpcId,
     stream: BoxStream<'static, Result<T, a2a::A2AError>>,
 ) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
+    let mut counter = 0u64;
     let sse_stream = stream.map(move |item| {
+        counter += 1;
         let data = match item {
             Ok(val) => {
                 let result_val = serde_json::to_value(&val).unwrap_or_default();
@@ -42,9 +55,9 @@ pub fn sse_jsonrpc_stream<T: serde::Serialize + Send + 'static>(
                 serde_json::to_string(&resp).unwrap_or_default()
             }
         };
-        Ok::<_, Infallible>(Event::default().data(data))
+        Ok::<_, Infallible>(Event::default().id(counter.to_string()).data(data))
     });
-    Sse::new(sse_stream)
+    Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 
 #[cfg(test)]
@@ -68,6 +81,7 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("data:"));
         assert!(body_str.contains("value"));
+        assert!(body_str.contains("id: 1"));
     }
 
     #[tokio::test]
@@ -80,6 +94,7 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("data:"));
         assert!(body_str.contains("fail"));
+        assert!(body_str.contains("id: 1"));
     }
 
     #[tokio::test]
@@ -95,6 +110,7 @@ mod tests {
         assert!(body_str.contains("data:"));
         assert!(body_str.contains("jsonrpc"));
         assert!(body_str.contains("2.0"));
+        assert!(body_str.contains("id: 1"));
     }
 
     #[tokio::test]
@@ -107,6 +123,7 @@ mod tests {
         let body_str = String::from_utf8(body.to_vec()).unwrap();
         assert!(body_str.contains("fail"));
         assert!(body_str.contains("error"));
+        assert!(body_str.contains("id: 1"));
     }
 
     #[tokio::test]
@@ -127,5 +144,9 @@ mod tests {
             data_count >= 3,
             "expected >= 3 data lines, got {data_count}"
         );
+        // Event IDs must be present and monotonic.
+        assert!(body_str.contains("id: 1"));
+        assert!(body_str.contains("id: 2"));
+        assert!(body_str.contains("id: 3"));
     }
 }


### PR DESCRIPTION
## What changed

### 1. SSE events now carry monotonic IDs and a keep-alive 

**Problem:** Both SSE stream functions used `Event::default().data(...)` — no event `id` and no heartbeat. Proxies/load balancers can terminate idle SSE connections without heartbeats, and clients cannot implement resumable subscriptions without event IDs. Go and JS assign event IDs; Rust had neither.

**Fix (a2a-server/src/sse.rs):**
- `sse_from_stream` and `sse_jsonrpc_stream` now assign a monotonic, counter-based `id` to every event (`id: 1`, `id: 2`, ...), so clients can detect gaps and resume interrupted subscriptions.
- Both responses now attach `KeepAlive::new().interval(15s)` — axum emits an SSE comment frame (`:\n\n`) every 15 seconds to keep idle connections alive. (Note: `KeepAlive::text(":\n")` from the plan panics in axum 0.8 because comment text must not contain newlines; the built-in default comment frame is used instead.)

### 2. Explicit request body size limit of 10 MB 

**Problem:** No REST or JSON-RPC handler enforced a maximum request body size; a client could send a multi-GB JSON payload to exhaust server memory (same issue as across SDKs).

**Fix (a2a-server/src/rest.rs, a2a-server/src/jsonrpc.rs):**
- `rest_router` and `jsonrpc_router` now apply `DefaultBodyLimit::max(10 * 1024 * 1024)` (10 MB), so oversized request bodies are rejected with `413 Payload Too Large` instead of relying on the framework's implicit default.

## Testing

- `cargo test -p a2a-server-lf`: **128 passed, 0 failed** (+ 1 doc-test passed).
- New regression tests:
 - `sse::tests::test_sse_from_stream_ok` / `..._err` (updated): assert `id: 1` is present in the body.
 - `sse::tests::test_sse_jsonrpc_stream_ok` / `..._err` / `..._multiple_events` (updated): assert event IDs are present and monotonic (`id: 1`, `id: 2`, `id: 3`).
 - `rest::tests::test_send_message_body_over_limit_rejected`: an ~11 MB request body returns `413 PAYLOAD_TOO_LARGE`.
 - `jsonrpc::tests::test_send_message_body_over_limit_rejected`: same for the JSON-RPC binding.
- Behavior change: SSE responses now include `id:` fields and keep-alive comment frames; request bodies larger than 10 MB are rejected with 413. Both are additive hardening changes.
- Note: `examples` / `a2a-grpc` / `a2a-slimrpc` packages cannot be compiled in this environment (missing NASM for `aws-lc-sys`, missing `protoc`) — pre-existing environment limitation, unrelated to this change.

