### PR TITLE
fix(server): protect terminal task states and make cancel transition atomic

### DIFF
--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -651,11 +651,27 @@ impl RequestHandler for DefaultRequestHandler {
         params: &ServiceParams,
         req: CancelTaskRequest,
     ) -> Result<Task, A2AError> {
-        let task = self.load_task(&req.id).await?;
-
-        if task.status.state.is_terminal() {
-            return Err(A2AError::task_not_cancelable(&req.id));
+        // Idempotent: canceling a task that is already in a terminal state
+        // returns the current terminal task instead of an error (BUG-52).
+        if let Some(task) = self.task_store.get(&req.id).await? {
+            if task.status.state.is_terminal() {
+                return Ok(task);
+            }
+        } else {
+            return Err(A2AError::task_not_found(&req.id));
         }
+
+        // Atomically transition the task to CANCELED so two concurrent cancel
+        // requests cannot both pass the check-then-act window (BUG-44).
+        let task = match self.task_store.begin_cancel(&req.id).await {
+            Ok(task) => task,
+            Err(error) if error.code == error_code::TASK_NOT_CANCELABLE => {
+                // Raced with another cancel or with task completion: return
+                // the current task (idempotent).
+                return self.load_task(&req.id).await;
+            }
+            Err(error) => return Err(error),
+        };
 
         let active_execution = self.execution_manager.get(&req.id).await;
 
@@ -1205,6 +1221,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_cancel_task_concurrent_both_succeed_idempotently() {
+        let handler = Arc::new(make_handler());
+        let params = ServiceParams::new();
+        let task = Task {
+            id: "t-race".into(),
+            context_id: "c-race".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        handler.task_store.create(task).await.unwrap();
+
+        let handlers = vec![Arc::clone(&handler), Arc::clone(&handler)];
+        let mut results = Vec::new();
+        for handler in handlers {
+            let params = params.clone();
+            let req = CancelTaskRequest {
+                id: "t-race".into(),
+                metadata: None,
+                tenant: None,
+            };
+            results.push(tokio::spawn(async move {
+                handler.cancel_task(&params, req).await
+            }));
+        }
+        for result in results {
+            let task = result.await.unwrap().unwrap();
+            assert_eq!(task.status.state, TaskState::Canceled);
+        }
+    }
+
+    #[tokio::test]
     async fn test_cancel_task_already_completed() {
         let handler = make_handler();
         let params = ServiceParams::new();
@@ -1226,8 +1279,9 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        let result = handler.cancel_task(&params, req).await;
-        assert!(result.is_err());
+        // Cancel on a terminal task is idempotent: the current task is returned.
+        let result = handler.cancel_task(&params, req).await.unwrap();
+        assert_eq!(result.status.state, TaskState::Completed);
     }
 
     #[tokio::test]

--- a/a2a-server/src/task_store/inmemory.rs
+++ b/a2a-server/src/task_store/inmemory.rs
@@ -48,9 +48,36 @@ impl TaskStore for InMemoryTaskStore {
         let entry = store
             .get_mut(&task.id)
             .ok_or_else(|| A2AError::task_not_found(&task.id))?;
+        // BUG-43: a terminal task's state is immutable. Re-applying the same
+        // terminal state is allowed so idempotent re-emission (e.g. cancel
+        // flows) keeps working, but a terminal state can never be overwritten
+        // by a different state.
+        if entry.task.status.state.is_terminal() && entry.task.status.state != task.status.state {
+            return Err(A2AError::invalid_request(format!(
+                "task {} is in terminal state {:?} and cannot transition to {:?}",
+                task.id, entry.task.status.state, task.status.state
+            )));
+        }
         entry.version += 1;
         entry.task = task;
         Ok(entry.version)
+    }
+
+    async fn begin_cancel(&self, task_id: &str) -> Result<Task, A2AError> {
+        // Hold the write lock across the check and the state transition so two
+        // concurrent cancel requests cannot both pass the check-then-act window
+        // (BUG-44).
+        let mut store = self.tasks.write().await;
+        let entry = store
+            .get_mut(task_id)
+            .ok_or_else(|| A2AError::task_not_found(task_id))?;
+        if entry.task.status.state.is_terminal() {
+            return Err(A2AError::task_not_cancelable(task_id));
+        }
+        entry.version += 1;
+        entry.task.status.state = TaskState::Canceled;
+        entry.task.status.timestamp = Some(chrono::Utc::now());
+        Ok(entry.task.clone())
     }
 
     async fn get(&self, task_id: &str) -> Result<Option<Task>, A2AError> {
@@ -194,6 +221,86 @@ mod tests {
         let task = make_task("t1", "c1", TaskState::Working);
         let result = store.update(task).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_terminal_state_rejected() {
+        let store = InMemoryTaskStore::new();
+        store
+            .create(make_task("t1", "c1", TaskState::Completed))
+            .await
+            .unwrap();
+
+        // A terminal task cannot transition to a different state.
+        for state in [
+            TaskState::Submitted,
+            TaskState::Working,
+            TaskState::Canceled,
+            TaskState::Failed,
+        ] {
+            let result = store.update(make_task("t1", "c1", state.clone())).await;
+            assert!(
+                result.is_err(),
+                "expected {state:?} update to be rejected"
+            );
+            assert_eq!(
+                result.unwrap_err().code,
+                error_code::INVALID_REQUEST,
+                "unexpected code for {state:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_terminal_same_state_allowed() {
+        let store = InMemoryTaskStore::new();
+        let mut task = make_task("t1", "c1", TaskState::Canceled);
+        store.create(task.clone()).await.unwrap();
+
+        // Re-applying the same terminal state (idempotent re-emission) is fine.
+        task.status.message = Some(Message::new(Role::Agent, vec![Part::text("after cancel")]));
+        let ver = store.update(task).await.unwrap();
+        assert_eq!(ver, 2);
+        let got = store.get("t1").await.unwrap().unwrap();
+        assert_eq!(got.status.state, TaskState::Canceled);
+        assert!(got.status.message.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_begin_cancel_transitions_non_terminal() {
+        let store = InMemoryTaskStore::new();
+        store
+            .create(make_task("t1", "c1", TaskState::Working))
+            .await
+            .unwrap();
+
+        let task = store.begin_cancel("t1").await.unwrap();
+        assert_eq!(task.status.state, TaskState::Canceled);
+
+        // A second cancel on the now-terminal task fails.
+        let result = store.begin_cancel("t1").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::TASK_NOT_CANCELABLE);
+    }
+
+    #[tokio::test]
+    async fn test_begin_cancel_terminal_rejected() {
+        let store = InMemoryTaskStore::new();
+        store
+            .create(make_task("t1", "c1", TaskState::Completed))
+            .await
+            .unwrap();
+        let result = store.begin_cancel("t1").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::TASK_NOT_CANCELABLE);
+    }
+
+    #[tokio::test]
+    async fn test_begin_cancel_not_found() {
+        let store = InMemoryTaskStore::new();
+        let result = store.begin_cancel("nonexistent").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::TASK_NOT_FOUND);
     }
 
     #[tokio::test]

--- a/a2a-server/src/task_store/store.rs
+++ b/a2a-server/src/task_store/store.rs
@@ -27,4 +27,29 @@ pub trait TaskStore: Send + Sync + 'static {
 
     /// List tasks matching the request criteria.
     async fn list(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError>;
+
+    /// Atomically check that a task is not in a terminal state and transition
+    /// it to `CANCELED`, returning the updated task.
+    ///
+    /// Used to eliminate the check-then-act TOCTOU race between concurrent
+    /// cancel requests (BUG-44). Fails with `TASK_NOT_CANCELABLE` if the task
+    /// is already terminal, and `TASK_NOT_FOUND` if it does not exist.
+    ///
+    /// The default implementation performs a non-atomic read + update; stores
+    /// with locking should override it so the check and the transition are
+    /// serialized.
+    async fn begin_cancel(&self, task_id: &str) -> Result<Task, A2AError> {
+        let task = self
+            .get(task_id)
+            .await?
+            .ok_or_else(|| A2AError::task_not_found(task_id))?;
+        if task.status.state.is_terminal() {
+            return Err(A2AError::task_not_cancelable(task_id));
+        }
+        let mut task = task;
+        task.status.state = TaskState::Canceled;
+        task.status.timestamp = Some(chrono::Utc::now());
+        self.update(task.clone()).await?;
+        Ok(task)
+    }
 }


### PR DESCRIPTION
## What changed

### 1. Terminal task states can no longer be blindly overwritten 

**Problem:** `InMemoryTaskStore::update` (and `handler::save_task`) wrote whatever state arrived, with no state-machine validation. A task in `COMPLETED` could be overwritten to `SUBMITTED` or `CANCELED` by a direct state assignment or a racing executor event.

**Fix (a2a-server/src/task_store/inmemory.rs):**
- `InMemoryTaskStore::update` now rejects any update that changes the state of a terminal task (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) with `INVALID_REQUEST`. Re-applying the *same* terminal state is still allowed so idempotent re-emission (e.g. cancel flows that re-emit the terminal event) keeps working; artifact/message-only updates on a terminal task remain possible, but the state itself is immutable.

### 2. Cancel check-then-act race made atomic 

**Problem:** `cancel_task` implemented cancel as check-then-act: it read the task, checked it was not terminal, then let the executor drive store writes. Two concurrent cancel requests could both pass the check; a cancel could also race with task completion, with no atomicity between the check and the state transition.

**Fix (a2a-server/src/task_store/store.rs, a2a-server/src/task_store/inmemory.rs, a2a-server/src/handler.rs):**
- Added `TaskStore::begin_cancel(task_id)` — atomically checks the task is non-terminal and transitions it to `CANCELED` under one write lock (returns `TASK_NOT_CANCELABLE` if already terminal, `TASK_NOT_FOUND` if missing). The trait provides a non-atomic default implementation (get + check + update) so existing custom stores keep compiling; `InMemoryTaskStore` overrides it with the lock-held version.
- `cancel_task` now: (1) returns the current task idempotently if it is already terminal; (2) performs the atomic `begin_cancel` transition; (3) if `begin_cancel` races with completion or another cancel (`TASK_NOT_CANCELABLE`), reloads and returns the current task idempotently; (4) drives the executor's cancel stream to completion as before.

## Testing

- `cargo test -p a2a-server-lf`: **132 passed, 0 failed** (+ 1 doc-test passed).
- New regression tests:
 - `task_store::inmemory::tests::test_update_terminal_state_rejected`
 - `task_store::inmemory::tests::test_update_terminal_same_state_allowed`
 - `task_store::inmemory::tests::test_begin_cancel_transitions_non_terminal`
 - `task_store::inmemory::tests::test_begin_cancel_terminal_rejected`
 - `task_store::inmemory::tests::test_begin_cancel_not_found`
 - `handler::tests::test_cancel_task_concurrent_both_succeed_idempotently` (two concurrent cancels both succeed and end in `CANCELED`)
- Updated existing test: `handler::tests::test_cancel_task_already_completed` now asserts cancel-on-terminal returns the current `COMPLETED` task (idempotent success) instead of an error — same behavior change as (the two PRs touch this test identically).
- Behavior change: direct updates that change a terminal task's state are now rejected (`INVALID_REQUEST`); concurrent cancels and cancel-vs-completion races now resolve idempotently instead of racing. Normal task lifecycle (Submitted → Working → Completed) is unaffected.
- Note: `examples` / `a2a-grpc` / `a2a-slimrpc` packages cannot be compiled in this environment (missing NASM for `aws-lc-sys`, missing `protoc`) — pre-existing environment limitation, unrelated to this change.

