### PR TITLE
feat(stdio): add A2A STDIO protocol binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "a2a-stdio"
+version = "0.1.0"
+dependencies = [
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-pb",
+ "a2a-server-lf",
+ "async-trait",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "agntcy-slim-auth"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "a2a-pb",
     "a2a-grpc",
     "a2a-slimrpc",
+    "a2a-stdio",
     "a2acli",
     "examples",
     "itk",
@@ -18,6 +19,7 @@ default-members = [
     "a2a-pb",
     "a2a-grpc",
     "a2a-slimrpc",
+    "a2a-stdio",
     "a2acli",
     "examples",
 ]
@@ -38,6 +40,7 @@ a2a-server = { package = "a2a-server-lf", path = "a2a-server", version = "0.4.3"
 a2a-pb = { package = "a2a-pb", path = "a2a-pb", version = "0.2.0" }
 a2a-grpc = { package = "a2a-grpc", path = "a2a-grpc", version = "0.3.5", default-features = false }
 a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.2.7" }
+a2a-stdio = { package = "a2a-stdio", path = "a2a-stdio", version = "0.1.0" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -52,6 +55,7 @@ futures = "0.3"
 async-stream = "0.3"
 async-trait = "0.1"
 pin-project-lite = "0.2"
+tokio-util = { version = "0.7", features = ["codec"] }
 
 # HTTP
 axum = { version = "0.8", features = ["macros"] }
@@ -93,3 +97,4 @@ semver = "1"
 tracing = "0.1"
 auto_impl = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+bytes = "1"

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -44,7 +44,12 @@ pub fn default_reqwest_client(
         .map_err(|e| a2a::A2AError::internal(format!("failed to build HTTP client: {e}")))
 }
 
-pub(crate) fn a2a_error_from_details(
+/// Rebuild an [`a2a::A2AError`] from a wire error plus its typed details.
+///
+/// Public so that protocol bindings living in other crates map errors the same
+/// way this one does; a binding that reimplemented it would quietly disagree
+/// about codes for the same server response.
+pub fn a2a_error_from_details(
     code: i32,
     message: String,
     details: Vec<a2a::TypedDetail>,

--- a/a2a-server/src/dispatch.rs
+++ b/a2a-server/src/dispatch.rs
@@ -1,0 +1,108 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::handler::RequestHandler;
+use crate::middleware::ServiceParams;
+use a2a::*;
+use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
+use futures::{StreamExt, stream::BoxStream};
+use serde_json::Value;
+
+fn decode<T: ProtoJsonPayload>(value: Value) -> Result<T, A2AError> {
+    protojson_conv::from_value(value).map_err(parse_error)
+}
+
+fn encode<T: ProtoJsonPayload>(value: &T) -> Result<Value, A2AError> {
+    protojson_conv::to_value(value)
+        .map_err(|e| A2AError::internal(format!("failed to serialize ProtoJSON payload: {e}")))
+}
+
+fn encode_stream(
+    stream: BoxStream<'static, Result<StreamResponse, A2AError>>,
+) -> BoxStream<'static, Result<Value, A2AError>> {
+    Box::pin(stream.map(|item| {
+        item.and_then(|value| {
+            protojson_conv::to_value(&value).map_err(|e| {
+                A2AError::internal(format!("failed to serialize ProtoJSON stream payload: {e}"))
+            })
+        })
+    }))
+}
+
+fn parse_error(e: impl std::fmt::Display) -> A2AError {
+    A2AError {
+        code: error_code::PARSE_ERROR,
+        message: format!("invalid params: {e}"),
+        details: None,
+    }
+}
+
+pub async fn dispatch_unary<H>(
+    handler: &H,
+    params: &ServiceParams,
+    method: &str,
+    raw_params: Value,
+) -> Result<Value, A2AError>
+where
+    H: RequestHandler + ?Sized,
+{
+    match method {
+        methods::SEND_MESSAGE => encode(&handler.send_message(params, decode(raw_params)?).await?),
+        methods::GET_TASK => encode(&handler.get_task(params, decode(raw_params)?).await?),
+        methods::LIST_TASKS => encode(&handler.list_tasks(params, decode(raw_params)?).await?),
+        methods::CANCEL_TASK => encode(&handler.cancel_task(params, decode(raw_params)?).await?),
+
+        methods::CREATE_PUSH_CONFIG => {
+            let req: TaskPushNotificationConfig = decode(raw_params)?;
+            encode(&handler.create_push_config(params, req).await?)
+        }
+        methods::GET_PUSH_CONFIG => {
+            encode(&handler.get_push_config(params, decode(raw_params)?).await?)
+        }
+        methods::LIST_PUSH_CONFIGS => encode(
+            &handler
+                .list_push_configs(params, decode(raw_params)?)
+                .await?,
+        ),
+        methods::DELETE_PUSH_CONFIG => {
+            handler
+                .delete_push_config(params, decode(raw_params)?)
+                .await?;
+            Ok(Value::Null)
+        }
+        methods::GET_EXTENDED_AGENT_CARD => encode(
+            &handler
+                .get_extended_agent_card(params, decode(raw_params)?)
+                .await?,
+        ),
+
+        "" => Err(A2AError::invalid_request("method is required")),
+        _ => Err(A2AError::method_not_found(method)),
+    }
+}
+
+pub async fn dispatch_streaming<H>(
+    handler: &H,
+    params: &ServiceParams,
+    method: &str,
+    raw_params: Value,
+) -> Result<BoxStream<'static, Result<Value, A2AError>>, A2AError>
+where
+    H: RequestHandler + ?Sized,
+{
+    match method {
+        methods::SEND_STREAMING_MESSAGE => {
+            let s = handler
+                .send_streaming_message(params, decode(raw_params)?)
+                .await?;
+            Ok(encode_stream(s))
+        }
+        methods::SUBSCRIBE_TO_TASK => {
+            let s = handler
+                .subscribe_to_task(params, decode(raw_params)?)
+                .await?;
+            Ok(encode_stream(s))
+        }
+        _ => Err(A2AError::method_not_found(method)),
+    }
+}

--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -3,16 +3,15 @@
 use std::sync::Arc;
 
 use a2a::*;
-use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
 use axum::{
     Json,
     extract::State,
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
-use futures::{StreamExt, stream::BoxStream};
 use serde_json::Value;
 
+use crate::dispatch;
 use crate::handler::RequestHandler;
 use crate::middleware::{ServiceParams, extract_service_params};
 use crate::sse;
@@ -69,98 +68,8 @@ async fn handle_unary_request<H: RequestHandler>(
     let id = request.id.clone();
     let raw_params = request.params.clone().unwrap_or(Value::Null);
 
-    let result: Result<Value, A2AError> = match request.method.as_str() {
-        methods::SEND_MESSAGE => match protojson_conv::from_value::<SendMessageRequest>(raw_params)
-        {
-            Ok(req) => state
-                .handler
-                .send_message(params, req)
-                .await
-                .and_then(|r| protojson_value(&r)),
-            Err(e) => Err(parse_error(e)),
-        },
-        methods::GET_TASK => match protojson_conv::from_value::<GetTaskRequest>(raw_params) {
-            Ok(req) => state
-                .handler
-                .get_task(params, req)
-                .await
-                .and_then(|r| protojson_value(&r)),
-            Err(e) => Err(parse_error(e)),
-        },
-        methods::LIST_TASKS => match protojson_conv::from_value::<ListTasksRequest>(raw_params) {
-            Ok(req) => state
-                .handler
-                .list_tasks(params, req)
-                .await
-                .and_then(|r| protojson_value(&r)),
-            Err(e) => Err(parse_error(e)),
-        },
-        methods::CANCEL_TASK => match protojson_conv::from_value::<CancelTaskRequest>(raw_params) {
-            Ok(req) => state
-                .handler
-                .cancel_task(params, req)
-                .await
-                .and_then(|r| protojson_value(&r)),
-            Err(e) => Err(parse_error(e)),
-        },
-        methods::CREATE_PUSH_CONFIG => match parse_create_push_config_request(raw_params) {
-            Ok(req) => state
-                .handler
-                .create_push_config(params, req)
-                .await
-                .and_then(|r| protojson_value(&r)),
-            Err(e) => Err(parse_error(e)),
-        },
-        methods::GET_PUSH_CONFIG => {
-            match protojson_conv::from_value::<GetTaskPushNotificationConfigRequest>(raw_params) {
-                Ok(req) => state
-                    .handler
-                    .get_push_config(params, req)
-                    .await
-                    .and_then(|r| protojson_value(&r)),
-                Err(e) => Err(parse_error(e)),
-            }
-        }
-        methods::LIST_PUSH_CONFIGS => {
-            match protojson_conv::from_value::<ListTaskPushNotificationConfigsRequest>(raw_params) {
-                Ok(req) => state
-                    .handler
-                    .list_push_configs(params, req)
-                    .await
-                    .and_then(|r| protojson_value(&r)),
-                Err(e) => Err(parse_error(e)),
-            }
-        }
-        methods::DELETE_PUSH_CONFIG => {
-            match protojson_conv::from_value::<DeleteTaskPushNotificationConfigRequest>(raw_params)
-            {
-                Ok(req) => state
-                    .handler
-                    .delete_push_config(params, req)
-                    .await
-                    .map(|_| Value::Null),
-                Err(e) => Err(parse_error(e)),
-            }
-        }
-        methods::GET_EXTENDED_AGENT_CARD => {
-            match protojson_conv::from_value::<GetExtendedAgentCardRequest>(raw_params) {
-                Ok(req) => state
-                    .handler
-                    .get_extended_agent_card(params, req)
-                    .await
-                    .and_then(|r| protojson_value(&r)),
-                Err(e) => Err(parse_error(e)),
-            }
-        }
-        "" => Err(A2AError::invalid_request("method is required")),
-        _ => Err(A2AError::method_not_found(&request.method)),
-    };
-
-    match result {
-        Ok(value) => {
-            let resp = JsonRpcResponse::success(id, value);
-            Json(resp).into_response()
-        }
+    match dispatch::dispatch_unary(&*state.handler, params, &request.method, raw_params).await {
+        Ok(value) => Json(JsonRpcResponse::success(id, value)).into_response(),
         Err(e) => error_response(id, e),
     }
 }
@@ -173,67 +82,15 @@ async fn handle_streaming_request<H: RequestHandler>(
     let id = request.id.clone();
     let raw_params = request.params.clone().unwrap_or(Value::Null);
 
-    match request.method.as_str() {
-        methods::SEND_STREAMING_MESSAGE => {
-            match protojson_conv::from_value::<SendMessageRequest>(raw_params) {
-                Ok(req) => match state.handler.send_streaming_message(params, req).await {
-                    Ok(stream) => {
-                        sse::sse_jsonrpc_stream(id, protojson_stream(stream)).into_response()
-                    }
-                    Err(e) => error_response(id, e),
-                },
-                Err(e) => error_response(id, parse_error(e)),
-            }
-        }
-        methods::SUBSCRIBE_TO_TASK => {
-            match protojson_conv::from_value::<SubscribeToTaskRequest>(raw_params) {
-                Ok(req) => match state.handler.subscribe_to_task(params, req).await {
-                    Ok(stream) => {
-                        sse::sse_jsonrpc_stream(id, protojson_stream(stream)).into_response()
-                    }
-                    Err(e) => error_response(id, e),
-                },
-                Err(e) => error_response(id, parse_error(e)),
-            }
-        }
-        _ => error_response(id, A2AError::method_not_found(&request.method)),
+    match dispatch::dispatch_streaming(&*state.handler, params, &request.method, raw_params).await {
+        Ok(stream) => sse::sse_jsonrpc_stream(id, stream).into_response(),
+        Err(e) => error_response(id, e),
     }
 }
 
 fn error_response(id: JsonRpcId, err: A2AError) -> axum::response::Response {
     let resp = JsonRpcResponse::error(id, err.to_jsonrpc_error());
     (StatusCode::OK, Json(resp)).into_response()
-}
-
-fn protojson_value<T: ProtoJsonPayload>(value: &T) -> Result<Value, A2AError> {
-    protojson_conv::to_value(value)
-        .map_err(|e| A2AError::internal(format!("failed to serialize ProtoJSON payload: {e}")))
-}
-
-fn protojson_stream(
-    stream: BoxStream<'static, Result<StreamResponse, A2AError>>,
-) -> BoxStream<'static, Result<Value, A2AError>> {
-    Box::pin(stream.map(|item| {
-        item.and_then(|value| {
-            protojson_conv::to_value(&value).map_err(|e| {
-                A2AError::internal(format!("failed to serialize ProtoJSON stream payload: {e}"))
-            })
-        })
-    }))
-}
-
-fn parse_create_push_config_request(
-    raw_params: Value,
-) -> Result<TaskPushNotificationConfig, String> {
-    protojson_conv::from_value::<TaskPushNotificationConfig>(raw_params).map_err(|e| e.to_string())
-}
-
-fn parse_error(e: impl std::fmt::Display) -> A2AError {
-    A2AError {
-        code: error_code::PARSE_ERROR,
-        message: format!("invalid params: {e}"),
-        details: None,
-    }
 }
 
 #[cfg(test)]

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 pub mod agent_card;
+pub mod dispatch;
 pub mod executor;
 pub mod handler;
 pub mod jsonrpc;

--- a/a2a-stdio/Cargo.toml
+++ b/a2a-stdio/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "a2a-stdio"
+version = "0.1.0"
+description = "A2A v1 STDIO protocol binding for client and server"
+readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "a2a_stdio"
+
+
+[dependencies]
+a2a = { workspace = true }
+# No TLS features are forwarded: this binding has no network layer (12).
+a2a-client = { workspace = true, default-features = false }
+a2a-server = { workspace = true, default-features = false }
+a2a-pb = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+bytes = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+# 2.1 wants a UUID session id, generated once per spawn.
+uuid = { workspace = true }
+
+[dev-dependencies]
+# `test-util` is not part of tokio's `full`, and the shutdown grace window is
+# only testable by pausing the clock.
+tokio = { workspace = true, features = ["test-util"] }

--- a/a2a-stdio/src/client.rs
+++ b/a2a-stdio/src/client.rs
@@ -1,0 +1,1528 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client side of the binding: the parent that spawns (2, 13).
+//!
+//! The mirror of [`crate::server`], with the roles inverted. One pipe pair
+//! carries every call, so the same three-role split applies: a writer owning the
+//! child's `STDIN`, a reader owning its `STDOUT`, and callers that never touch
+//! either. What the server calls dispatch, this side calls correlation — a
+//! response is matched to its caller by the `id` it was issued under (3.6),
+//! because a pipe preserves no other association.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use a2a::*;
+use a2a_client::{ServiceParams, Transport};
+use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::{SinkExt, Stream, StreamExt};
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use crate::codec::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_HEADER_SIZE, StdioCodec};
+use crate::frame::{Frame, FrameHeaders};
+use crate::json::{self, ClientInbound, ClientMessage, ServerMessage, StdioRequest};
+use crate::session::{self, NegotiationError};
+use crate::wire::{ControlFrame, Variant};
+
+/// Variants this client can actually speak, most preferred first.
+///
+/// 2.2 lets the server rank its own list and the client only veto, so this is a
+/// capability set rather than a preference. It gains `stdio-proto` when 15 lands.
+const SUPPORTED_VARIANTS: &[Variant] = &[Variant::Json];
+
+pub struct ClientConfig {
+    pub max_frame_size: usize,
+    pub max_header_size: usize,
+    /// Depth of the queue feeding the writer task.
+    pub outbound_capacity: usize,
+    /// Per-stream buffer. Reaching it stalls the reader, which is the only
+    /// backpressure available when every stream shares one pipe (13.4).
+    pub stream_capacity: usize,
+    /// How long [`Transport::destroy`] waits for the child to exit (2.4).
+    pub shutdown_timeout: Duration,
+    /// Whether `destroy` asks with `system/shutdown` before closing `STDIN`.
+    /// 2.4 makes this optional and 6.9 makes it an extension, so an agent that
+    /// does not implement it answers `MethodNotFound` and exits on EOF anyway.
+    pub send_shutdown_request: bool,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        ClientConfig {
+            max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+            max_header_size: DEFAULT_MAX_HEADER_SIZE,
+            outbound_capacity: 64,
+            stream_capacity: 64,
+            shutdown_timeout: Duration::from_secs(5), // 2.4 recommends 5 s
+            send_shutdown_request: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Launch descriptor
+// ---------------------------------------------------------------------------
+
+/// How to spawn an agent (2.1), built to make the 13.1 rules unavoidable.
+///
+/// Program and arguments stay separate values all the way to `execve`, so there
+/// is no point at which a shell could interpret them. Callers are still
+/// responsible for the checks this type cannot make: resolving the program
+/// against an allowlist of trusted binaries, and verifying its provenance.
+pub struct Launch {
+    program: OsString,
+    args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
+    current_dir: Option<PathBuf>,
+    session_id: String,
+    inherit_env: bool,
+}
+
+impl Launch {
+    /// Starts with an empty environment and a fresh session id; add only what
+    /// the agent needs.
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Launch {
+            program: program.into(),
+            args: Vec::new(),
+            envs: Vec::new(),
+            current_dir: None,
+            session_id: uuid::Uuid::now_v7().to_string(),
+            inherit_env: false,
+        }
+    }
+
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn current_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(dir.into());
+        self
+    }
+
+    /// Override the generated `A2A_SESSION_ID`. The server echoes it in the
+    /// handshake and a mismatch fails the session (2.2 step 2).
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.session_id = id.into();
+        self
+    }
+
+    /// 2.1: the A2A version this client intends to use.
+    pub fn protocol_version(self, version: impl Into<OsString>) -> Self {
+        self.env(session::ENV_PROTOCOL_VERSION, version)
+    }
+
+    pub fn log_level(self, level: impl Into<OsString>) -> Self {
+        self.env(session::ENV_LOG_LEVEL, level)
+    }
+
+    /// 4.1: session-scoped parameters, the inverse of
+    /// [`session::service_params_from_env`].
+    pub fn service_params(mut self, params: &ServiceParams) -> Self {
+        for (key, values) in params {
+            let name = format!(
+                "{}{}",
+                session::ENV_SERVICE_PARAM_PREFIX,
+                key.to_ascii_uppercase().replace('-', "_")
+            );
+            self = self.env(name, values.join(","));
+        }
+        self
+    }
+
+    /// Pass the parent's whole environment through. 13.2 argues against it:
+    /// the child then sees every unrelated secret this process holds.
+    pub fn inherit_env(mut self, inherit: bool) -> Self {
+        self.inherit_env = inherit;
+        self
+    }
+
+    fn build(&self) -> Command {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args);
+        if !self.inherit_env {
+            cmd.env_clear();
+        }
+        cmd.env(session::ENV_SESSION_ID, &self.session_id);
+        for (key, value) in &self.envs {
+            cmd.env(key, value);
+        }
+        if let Some(dir) = &self.current_dir {
+            cmd.current_dir(dir);
+        }
+        cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+        // 13.3 and 14: diagnostics must never reach the protocol stream, so
+        // they are passed through to ours instead of being read as frames.
+        cmd.stderr(Stdio::inherit());
+        // 13.4: a transport dropped without `destroy` must not leak a process.
+        cmd.kill_on_drop(true);
+        cmd
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+/// A2A client over one spawned agent process.
+pub struct StdioTransport {
+    session: Arc<Session>,
+}
+
+/// Only the negotiated identity: 13.5 keeps payloads out of diagnostics.
+impl std::fmt::Debug for StdioTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StdioTransport")
+            .field("session_id", &self.session.session_id)
+            .field("variant", &self.session.variant)
+            .field("alive", &self.session.alive.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+type Pendings = Arc<Mutex<HashMap<JsonRpcId, Pending>>>;
+
+/// A caller waiting on an `id`. 3.5 makes a unary response and a stream chunk
+/// byte-identical, so which of these is registered is what tells them apart.
+enum Pending {
+    Unary(oneshot::Sender<Result<Value, A2AError>>),
+    Stream(mpsc::Sender<Result<Value, A2AError>>),
+}
+
+impl Pending {
+    async fn fail(self, error: A2AError) {
+        match self {
+            Pending::Unary(tx) => {
+                let _ = tx.send(Err(error));
+            }
+            Pending::Stream(tx) => {
+                let _ = tx.send(Err(error)).await;
+            }
+        }
+    }
+}
+
+struct Session {
+    /// `None` once [`Session::shutdown`] has run. Dropping the last sender is
+    /// what closes the child's `STDIN`, so this doubles as the closed flag.
+    outbound: Mutex<Option<mpsc::Sender<Frame>>>,
+    pending: Pendings,
+    /// Cleared by the reader task when the agent's `STDOUT` ends.
+    alive: Arc<AtomicBool>,
+    next_id: AtomicU64,
+    session_id: String,
+    variant: Variant,
+    features: Vec<String>,
+    child: tokio::sync::Mutex<Option<Child>>,
+    stream_capacity: usize,
+    shutdown_timeout: Duration,
+    send_shutdown_request: bool,
+}
+
+impl StdioTransport {
+    /// Spawn an agent and complete the handshake (2.1, 2.2).
+    pub async fn connect(launch: Launch, config: ClientConfig) -> Result<Self, A2AError> {
+        let session_id = launch.session_id.clone();
+        let mut child = launch
+            .build()
+            .spawn()
+            .map_err(|e| A2AError::internal(format!("cannot spawn agent: {e}")))?;
+
+        // Both were requested as pipes above, so absence is a bug, not input.
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| A2AError::internal("child STDOUT is not a pipe"))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| A2AError::internal("child STDIN is not a pipe"))?;
+
+        // `kill_on_drop` reaps the child if the handshake below fails.
+        start(stdout, stdin, session_id, config, Some(child)).await
+    }
+
+    /// Complete the handshake over pipes obtained some other way.
+    ///
+    /// 2 permits attaching to an already-running process. Termination is then
+    /// the caller's problem: [`Transport::destroy`] can close `STDIN` but has no
+    /// process to wait on or kill.
+    pub async fn attach<R, W>(
+        stdout: R,
+        stdin: W,
+        session_id: impl Into<String>,
+        config: ClientConfig,
+    ) -> Result<Self, A2AError>
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        start(stdout, stdin, session_id.into(), config, None).await
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session.session_id
+    }
+
+    pub fn variant(&self) -> Variant {
+        self.session.variant
+    }
+
+    /// What the server advertised in the handshake (2.2), e.g. `streaming`.
+    pub fn server_features(&self) -> &[String] {
+        &self.session.features
+    }
+
+    async fn call<Req, Resp>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request: &Req,
+    ) -> Result<Resp, A2AError>
+    where
+        Req: ProtoJsonPayload,
+        Resp: ProtoJsonPayload,
+    {
+        let result = self.call_value(params, method, encode(request)?).await?;
+        decode(result)
+    }
+
+    async fn call_value(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        payload: Value,
+    ) -> Result<Value, A2AError> {
+        let id = self.session.next_id();
+        let (tx, rx) = oneshot::channel();
+        lock(&self.session.pending).insert(id.clone(), Pending::Unary(tx));
+        // From here every exit path, including the caller dropping this future,
+        // has to unregister; a leaked entry would outlive its waiter.
+        let _guard = Unregister {
+            pending: self.session.pending.clone(),
+            id: id.clone(),
+        };
+
+        self.session
+            .send(encode_request(&id, method, payload, params)?)
+            .await?;
+
+        match rx.await {
+            Ok(result) => result,
+            // The entry was dropped without an answer, which only the teardown
+            // path does, and it answers first. So the session is simply gone.
+            Err(_) => Err(A2AError::internal("stdio session ended before a response")),
+        }
+    }
+
+    async fn call_streaming<Req>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request: &Req,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError>
+    where
+        Req: ProtoJsonPayload,
+    {
+        let payload = encode(request)?;
+        let id = self.session.next_id();
+        let (tx, rx) = mpsc::channel(self.session.stream_capacity);
+        lock(&self.session.pending).insert(id.clone(), Pending::Stream(tx));
+
+        // The handle owns the registration from here, including the 8.5 cancel
+        // it sends if the consumer drops the stream early.
+        let mut handle = StreamHandle {
+            id: id.clone(),
+            rx,
+            session: self.session.clone(),
+            finished: false,
+        };
+        let frame = match encode_request(&id, method, payload, params) {
+            Ok(frame) => frame,
+            Err(e) => {
+                handle.finished = true;
+                return Err(e);
+            }
+        };
+        if let Err(e) = self.session.send(frame).await {
+            // Nothing reached the agent, so there is no stream to cancel.
+            handle.finished = true;
+            return Err(e);
+        }
+        Ok(Box::pin(handle))
+    }
+}
+
+/// Read the handshake, answer it, and start the reader and writer tasks.
+async fn start<R, W>(
+    stdout: R,
+    stdin: W,
+    session_id: String,
+    config: ClientConfig,
+    child: Option<Child>,
+) -> Result<StdioTransport, A2AError>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let mut reader = FramedRead::new(
+        stdout,
+        StdioCodec::new(config.max_frame_size, config.max_header_size),
+    );
+    let mut writer = FramedWrite::new(
+        stdin,
+        StdioCodec::new(config.max_frame_size, config.max_header_size),
+    );
+
+    // 2.2 step 1: the server speaks first, and this frame is always JSON.
+    let handshake = match reader.next().await {
+        Some(Ok(frame)) => match json::parse_from_server(&frame.body) {
+            Ok(ClientInbound::Control(ControlFrame::Handshake(hs))) => hs,
+            Ok(_) => {
+                return Err(A2AError::internal(
+                    "agent sent something other than a handshake as its first frame",
+                ));
+            }
+            Err(e) => return Err(A2AError::internal(format!("malformed handshake: {e}"))),
+        },
+        Some(Err(e)) => {
+            return Err(A2AError::internal(format!(
+                "framing error during handshake: {e}"
+            )));
+        }
+        None => {
+            return Err(A2AError::internal(
+                "agent closed STDOUT before sending a handshake",
+            ));
+        }
+    };
+
+    // 2.2 steps 2-3.
+    let (ack, variant) =
+        match session::respond_to_handshake(&handshake, &session_id, SUPPORTED_VARIANTS) {
+            Ok(pair) => pair,
+            Err(e) => {
+                // 2.2 step 4: refusing lets the agent exit 0 instead of waiting
+                // on an ack that is never coming.
+                let decline = ControlFrame::HandshakeAck(session::decline(&session_id));
+                if let Ok(frame) = encode_control(&decline) {
+                    let _ = writer.send(frame).await;
+                }
+                return Err(negotiation_failed(&e));
+            }
+        };
+    writer
+        .send(encode_control(&ControlFrame::HandshakeAck(ack))?)
+        .await
+        .map_err(|e| A2AError::internal(format!("cannot write handshakeAck: {e}")))?;
+
+    let (tx, rx) = mpsc::channel::<Frame>(config.outbound_capacity);
+    let pending: Pendings = Arc::new(Mutex::new(HashMap::new()));
+    let alive = Arc::new(AtomicBool::new(true));
+
+    tokio::spawn(write_loop(writer, rx));
+    tokio::spawn(read_loop(reader, pending.clone(), alive.clone()));
+
+    Ok(StdioTransport {
+        session: Arc::new(Session {
+            outbound: Mutex::new(Some(tx)),
+            pending,
+            alive,
+            next_id: AtomicU64::new(1),
+            session_id,
+            variant,
+            features: handshake.features,
+            child: tokio::sync::Mutex::new(child),
+            stream_capacity: config.stream_capacity,
+            shutdown_timeout: config.shutdown_timeout,
+            send_shutdown_request: config.send_shutdown_request,
+        }),
+    })
+}
+
+/// 2.2 step 4 asks the client to report why negotiation failed. Only the
+/// version case has an A2A code of its own; the rest are local protocol faults.
+fn negotiation_failed(e: &NegotiationError) -> A2AError {
+    match e {
+        NegotiationError::VersionNotSupported(v) => A2AError::version_not_supported(v),
+        other => A2AError::internal(format!("stdio handshake failed: {other}")),
+    }
+}
+
+/// The only task permitted to touch the child's `STDIN`.
+///
+/// Ends when every sender is gone, which drops the pipe and gives the agent the
+/// EOF that 2.4 uses as the shutdown signal.
+async fn write_loop<W>(mut sink: FramedWrite<W, StdioCodec>, mut rx: mpsc::Receiver<Frame>)
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(frame) = rx.recv().await {
+        if let Err(e) = sink.send(frame).await {
+            eprintln!("a2a-stdio: dropping outbound frame: {e}");
+            break;
+        }
+    }
+    let _ = sink.flush().await;
+}
+
+/// The only task reading the child's `STDOUT`, and so the only place a response
+/// can be matched to its caller.
+async fn read_loop<R>(
+    mut reader: FramedRead<R, StdioCodec>,
+    pending: Pendings,
+    alive: Arc<AtomicBool>,
+) where
+    R: AsyncRead + Unpin,
+{
+    let reason = loop {
+        let Some(item) = reader.next().await else {
+            break A2AError::internal("stdio session ended: agent closed STDOUT");
+        };
+        let frame = match item {
+            Ok(frame) => frame,
+            // Fatal, unlike a bad body below: a desynchronized byte stream
+            // cannot be resynchronized, and guessing where the next frame
+            // starts is how a hostile agent would get to choose (13.3).
+            Err(e) => break A2AError::internal(format!("stdio framing error: {e}")),
+        };
+        match json::parse_from_server(&frame.body) {
+            Err(e) => unreadable(&pending, &frame.body, e).await,
+            // 2.3: liveness only, and it resets nothing yet because this client
+            // does not negotiate heartbeats.
+            Ok(ClientInbound::Control(ControlFrame::Heartbeat(_))) => {}
+            // A lifecycle violation rather than a bad message: 2.2 runs the
+            // handshake once, so a second one means the agent's idea of the
+            // session no longer matches ours and no id can be trusted.
+            Ok(ClientInbound::Control(_)) => {
+                break A2AError::internal("agent repeated the handshake mid-session");
+            }
+            Ok(ClientInbound::Message(msg)) => deliver(&pending, msg).await,
+        }
+    };
+
+    alive.store(false, Ordering::SeqCst);
+    // 8.3: process exit terminates every active stream, and a unary caller
+    // would otherwise wait forever.
+    let orphans: Vec<Pending> = lock(&pending).drain().map(|(_, p)| p).collect();
+    for waiter in orphans {
+        waiter.fail(reason.clone()).await;
+    }
+}
+
+/// Absorb a frame whose body could not be read.
+///
+/// 3.1 forbids failing a message over content this side does not recognize, and
+/// `Content-Length` already told us where the frame ended, so the session is
+/// still intact. 3.4 keeps the id readable even when the shape is not, which
+/// puts the cost on the one caller that cannot be answered instead of on every
+/// in-flight request.
+async fn unreadable(pending: &Pendings, body: &[u8], error: crate::wire::WireError) {
+    eprintln!("a2a-stdio: ignoring an unreadable frame from the agent: {error}");
+    let id = json::peek_id(body);
+    if matches!(id, JsonRpcId::Null) {
+        return;
+    }
+    let waiter = lock(pending).remove(&id);
+    if let Some(waiter) = waiter {
+        waiter
+            .fail(A2AError::internal(format!(
+                "agent sent a response this client cannot read: {error}"
+            )))
+            .await;
+    }
+}
+
+/// Hand one server message to whoever is waiting on its `id`.
+///
+/// An `id` with no waiter is dropped, not an error: 8.5 lets a stream be
+/// cancelled while frames for it are already in the pipe.
+async fn deliver(pending: &Pendings, msg: ServerMessage) {
+    match msg {
+        ServerMessage::Result { id, result } => match claim(pending, &id) {
+            Some(Pending::Unary(tx)) => {
+                let _ = tx.send(Ok(result));
+            }
+            Some(Pending::Stream(tx)) => {
+                // Awaiting here stalls the pipe once a consumer falls behind,
+                // which is the only backpressure one shared pipe can express.
+                if tx.send(Ok(result)).await.is_err() {
+                    lock(pending).remove(&id);
+                }
+            }
+            None => {}
+        },
+
+        // 7.3 and 8.3: an error is terminal for a stream too, and no
+        // `streamEnd` follows it. Removing the entry drops the sender, which is
+        // what ends the consumer's stream after it sees this item.
+        ServerMessage::Error { id, error } => {
+            let waiter = lock(pending).remove(&id);
+            if let Some(waiter) = waiter {
+                waiter.fail(from_jsonrpc(error)).await;
+            }
+        }
+
+        ServerMessage::StreamEnd { id } => match lock(pending).remove(&id) {
+            Some(Pending::Unary(tx)) => {
+                let _ = tx.send(Err(A2AError::internal(
+                    "agent ended a stream for a unary request",
+                )));
+            }
+            // Dropping the sender is the end of the stream (8.3).
+            Some(Pending::Stream(_)) | None => {}
+        },
+    }
+}
+
+/// Take a unary waiter, or borrow a stream's sender without unregistering it.
+fn claim(pending: &Pendings, id: &JsonRpcId) -> Option<Pending> {
+    let mut map = lock(pending);
+    match map.get(id) {
+        Some(Pending::Stream(tx)) => Some(Pending::Stream(tx.clone())),
+        Some(Pending::Unary(_)) => map.remove(id),
+        None => None,
+    }
+}
+
+impl Session {
+    fn next_id(&self) -> JsonRpcId {
+        // 3.2 allows a number; uniqueness within the session is all 3.6 needs.
+        JsonRpcId::Number(self.next_id.fetch_add(1, Ordering::Relaxed) as i64)
+    }
+
+    fn sender(&self) -> Result<mpsc::Sender<Frame>, A2AError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(A2AError::internal("stdio session ended"));
+        }
+        lock(&self.outbound)
+            .clone()
+            .ok_or_else(|| A2AError::internal("stdio session is closed"))
+    }
+
+    async fn send(&self, frame: Frame) -> Result<(), A2AError> {
+        self.sender()?
+            .send(frame)
+            .await
+            .map_err(|_| A2AError::internal("stdio session is closed"))
+    }
+
+    /// 8.5: stop one stream without disturbing the session or the task behind
+    /// it. Called from `Drop`, so it cannot await and cannot report failure.
+    fn cancel_stream(&self, id: &JsonRpcId) {
+        let Ok(tx) = self.sender() else { return };
+        let Ok(body) = ClientMessage::CancelStream { id: id.clone() }.to_vec() else {
+            return;
+        };
+        let _ = tx.try_send(json_frame(body));
+    }
+
+    /// 2.4: ask, close `STDIN`, wait, then force.
+    async fn shutdown(&self) -> Result<(), A2AError> {
+        if self.send_shutdown_request {
+            // 6.9 is an extension, so a refusal is expected and ignored; EOF
+            // below is the part every agent must honour. No waiter is
+            // registered because the answer may never arrive.
+            if let Ok(frame) = encode_request(
+                &self.next_id(),
+                json::SYSTEM_SHUTDOWN,
+                Value::Object(Default::default()),
+                &ServiceParams::new(),
+            ) {
+                let _ = self.send(frame).await;
+            }
+        }
+
+        // Queued frames still drain: the writer sees them before the close.
+        lock(&self.outbound).take();
+
+        let mut slot = self.child.lock().await;
+        let Some(child) = slot.as_mut() else {
+            // Attached rather than spawned, so there is no process to reap.
+            return Ok(());
+        };
+        match tokio::time::timeout(self.shutdown_timeout, child.wait()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(A2AError::internal(format!("cannot reap agent: {e}"))),
+            Err(_) => {
+                // 13.4 forbids leaking the process, so the grace window is the
+                // whole negotiation. 2.4 suggests escalating through SIGTERM
+                // first; that needs a platform-specific signal call, and the
+                // agent has already had `shutdown_timeout` after EOF.
+                eprintln!(
+                    "a2a-stdio: agent outlived the {:?} shutdown window; killing it",
+                    self.shutdown_timeout
+                );
+                let _ = child.kill().await;
+            }
+        }
+        *slot = None;
+        Ok(())
+    }
+}
+
+/// Removes a registration when a caller's future is dropped before its answer.
+struct Unregister {
+    pending: Pendings,
+    id: JsonRpcId,
+}
+
+impl Drop for Unregister {
+    fn drop(&mut self) {
+        lock(&self.pending).remove(&self.id);
+    }
+}
+
+/// A server stream, plus the cleanup its lifetime implies.
+struct StreamHandle {
+    id: JsonRpcId,
+    rx: mpsc::Receiver<Result<Value, A2AError>>,
+    session: Arc<Session>,
+    finished: bool,
+}
+
+impl Stream for StreamHandle {
+    type Item = Result<StreamResponse, A2AError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.finished {
+            return Poll::Ready(None);
+        }
+        match this.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            // The registration was dropped: `streamEnd`, or the session ended.
+            Poll::Ready(None) => {
+                this.finished = true;
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(e))) => {
+                this.finished = true;
+                Poll::Ready(Some(Err(e)))
+            }
+            // A payload this client cannot read is reported per item rather than
+            // as the end of the stream: only the agent decides when that is.
+            Poll::Ready(Some(Ok(value))) => Poll::Ready(Some(decode(value))),
+        }
+    }
+}
+
+impl Drop for StreamHandle {
+    fn drop(&mut self) {
+        // Only an early drop needs cancelling; a stream the agent already ended
+        // has no server-side state left to stop.
+        if !self.finished {
+            self.session.cancel_stream(&self.id);
+        }
+        lock(&self.session.pending).remove(&self.id);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+fn encode<T: ProtoJsonPayload>(value: &T) -> Result<Value, A2AError> {
+    protojson_conv::to_value(value)
+        .map_err(|e| A2AError::internal(format!("failed to serialize ProtoJSON payload: {e}")))
+}
+
+fn decode<T: ProtoJsonPayload>(value: Value) -> Result<T, A2AError> {
+    protojson_conv::from_value(value)
+        .map_err(|e| A2AError::internal(format!("invalid response payload: {e}")))
+}
+
+/// 4.2 carries service parameters in the body, not in frame headers: the
+/// headers in 3.1 are the transport's, and a per-request parameter is the
+/// application's.
+fn encode_request(
+    id: &JsonRpcId,
+    method: &str,
+    payload: Value,
+    params: &ServiceParams,
+) -> Result<Frame, A2AError> {
+    let request = StdioRequest::new(id.clone(), method, Some(payload)).with_service_params(params);
+    let body = ClientMessage::Request(request)
+        .to_vec()
+        .map_err(|e| A2AError::internal(format!("cannot serialize request: {e}")))?;
+    Ok(json_frame(body))
+}
+
+fn encode_control(frame: &ControlFrame) -> Result<Frame, A2AError> {
+    let body = serde_json::to_vec(frame)
+        .map_err(|e| A2AError::internal(format!("cannot serialize control frame: {e}")))?;
+    Ok(json_frame(body))
+}
+
+/// No optional headers: 3.1 defaults `Content-Type` for `stdio-json`.
+fn json_frame(body: Vec<u8>) -> Frame {
+    Frame {
+        headers: FrameHeaders::default(),
+        body: Bytes::from(body),
+    }
+}
+
+/// 7.1 puts the same JSON-RPC error object on the wire as the HTTP binding, so
+/// the mapping is shared with the other clients rather than reimplemented.
+fn from_jsonrpc(error: JsonRpcError) -> A2AError {
+    let details: Vec<TypedDetail> = match error.data {
+        Some(Value::Array(items)) => items
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect(),
+        _ => Vec::new(),
+    };
+    a2a_client::a2a_error_from_details(error.code, error.message, details)
+}
+
+/// No invariant here survives a panic badly, so poisoning is recovered from.
+fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl Transport for StdioTransport {
+    async fn send_message(
+        &self,
+        params: &ServiceParams,
+        req: &SendMessageRequest,
+    ) -> Result<SendMessageResponse, A2AError> {
+        self.call(params, methods::SEND_MESSAGE, req).await
+    }
+
+    async fn send_streaming_message(
+        &self,
+        params: &ServiceParams,
+        req: &SendMessageRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.call_streaming(params, methods::SEND_STREAMING_MESSAGE, req)
+            .await
+    }
+
+    async fn get_task(
+        &self,
+        params: &ServiceParams,
+        req: &GetTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.call(params, methods::GET_TASK, req).await
+    }
+
+    async fn list_tasks(
+        &self,
+        params: &ServiceParams,
+        req: &ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
+        self.call(params, methods::LIST_TASKS, req).await
+    }
+
+    async fn cancel_task(
+        &self,
+        params: &ServiceParams,
+        req: &CancelTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.call(params, methods::CANCEL_TASK, req).await
+    }
+
+    async fn subscribe_to_task(
+        &self,
+        params: &ServiceParams,
+        req: &SubscribeToTaskRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.call_streaming(params, methods::SUBSCRIBE_TO_TASK, req)
+            .await
+    }
+
+    async fn create_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &TaskPushNotificationConfig,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        // Plain ProtoJSON, matching what this binding's server decodes. The
+        // HTTP JSON-RPC binding needs a compatibility shape here; stdio is new
+        // enough to have no legacy peer to accommodate.
+        self.call(params, methods::CREATE_PUSH_CONFIG, req).await
+    }
+
+    async fn get_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &GetTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.call(params, methods::GET_PUSH_CONFIG, req).await
+    }
+
+    async fn list_push_configs(
+        &self,
+        params: &ServiceParams,
+        req: &ListTaskPushNotificationConfigsRequest,
+    ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+        self.call(params, methods::LIST_PUSH_CONFIGS, req).await
+    }
+
+    async fn delete_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &DeleteTaskPushNotificationConfigRequest,
+    ) -> Result<(), A2AError> {
+        // The one method with no response body; the server answers `null`.
+        self.call_value(params, methods::DELETE_PUSH_CONFIG, encode(req)?)
+            .await
+            .map(|_| ())
+    }
+
+    async fn get_extended_agent_card(
+        &self,
+        params: &ServiceParams,
+        req: &GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard, A2AError> {
+        self.call(params, methods::GET_EXTENDED_AGENT_CARD, req)
+            .await
+    }
+
+    async fn destroy(&self) -> Result<(), A2AError> {
+        self.session.shutdown().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json::{ServerInbound, parse_from_client};
+    use crate::wire::Handshake;
+    use serde_json::json;
+    use tokio::io::DuplexStream;
+
+    const CAP: usize = 64 * 1024;
+
+    /// Stands in for the agent, so the whole session is exercised without
+    /// spawning a process: only `connect` differs from `attach` downstream.
+    struct Peer {
+        reader: FramedRead<DuplexStream, StdioCodec>,
+        writer: FramedWrite<DuplexStream, StdioCodec>,
+    }
+
+    impl Peer {
+        async fn recv(&mut self) -> ServerInbound {
+            let frame = self
+                .reader
+                .next()
+                .await
+                .expect("client sent nothing")
+                .expect("client sent a malformed frame");
+            parse_from_client(&frame.body).expect("client sent an unclassifiable frame")
+        }
+
+        async fn recv_request(&mut self) -> StdioRequest {
+            match self.recv().await {
+                ServerInbound::Message(ClientMessage::Request(r)) => r,
+                other => panic!("expected a request, got {other:?}"),
+            }
+        }
+
+        async fn send(&mut self, msg: ServerMessage) {
+            let frame = json_frame(msg.to_vec().unwrap());
+            self.writer.send(frame).await.unwrap();
+        }
+
+        async fn send_control(&mut self, frame: ControlFrame) {
+            self.writer
+                .send(encode_control(&frame).unwrap())
+                .await
+                .unwrap();
+        }
+
+        async fn send_raw(&mut self, body: Value) {
+            let frame = json_frame(serde_json::to_vec(&body).unwrap());
+            self.writer.send(frame).await.unwrap();
+        }
+
+        async fn result(&mut self, id: JsonRpcId, value: &impl ProtoJsonPayload) {
+            self.send(ServerMessage::Result {
+                id,
+                result: encode(value).unwrap(),
+            })
+            .await;
+        }
+    }
+
+    fn codec() -> StdioCodec {
+        StdioCodec::new(DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_HEADER_SIZE)
+    }
+
+    /// Two independent pipes rather than one split duplex.
+    ///
+    /// A child's `STDIN` and `STDOUT` are separate objects, so dropping the
+    /// writer closes one direction and leaves the other readable. Splitting a
+    /// single duplex would keep it alive through the read half and hide the EOF
+    /// that 2.4 shutdown depends on.
+    fn wire() -> (DuplexStream, DuplexStream, Peer) {
+        let (client_read, agent_write) = tokio::io::duplex(CAP);
+        let (agent_read, client_write) = tokio::io::duplex(CAP);
+        let peer = Peer {
+            reader: FramedRead::new(agent_read, codec()),
+            writer: FramedWrite::new(agent_write, codec()),
+        };
+        (client_read, client_write, peer)
+    }
+
+    fn offer(session_id: &str, variants: Vec<Variant>) -> ControlFrame {
+        ControlFrame::Handshake(Handshake {
+            protocol: session::PROTOCOL_NAME.into(),
+            protocol_version: session::PROTOCOL_VERSION.into(),
+            session_id: session_id.into(),
+            supported_variants: variants,
+            features: vec![session::FEATURE_STREAMING.into()],
+            pid: Some(1),
+        })
+    }
+
+    async fn connected(config: ClientConfig) -> (StdioTransport, Peer) {
+        let (client_read, client_write, mut peer) = wire();
+        peer.send_control(offer("s-1", vec![Variant::Json])).await;
+        let transport = StdioTransport::attach(client_read, client_write, "s-1", config)
+            .await
+            .expect("handshake failed");
+        match peer.recv().await {
+            ServerInbound::Control(ControlFrame::HandshakeAck(ack)) => {
+                assert!(ack.accept);
+                assert_eq!(ack.select_variant, Variant::Json);
+                assert_eq!(ack.session_id, "s-1");
+            }
+            other => panic!("expected handshakeAck, got {other:?}"),
+        }
+        (transport, peer)
+    }
+
+    fn sample_task(id: &str) -> Task {
+        Task {
+            id: id.into(),
+            context_id: "c-1".into(),
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        }
+    }
+
+    fn get_task(id: &str) -> GetTaskRequest {
+        GetTaskRequest {
+            id: id.into(),
+            history_length: None,
+            tenant: None,
+        }
+    }
+
+    fn subscribe(id: &str) -> SubscribeToTaskRequest {
+        SubscribeToTaskRequest {
+            id: id.into(),
+            tenant: None,
+        }
+    }
+
+    // ---- handshake (2.2) ------------------------------------------------
+
+    #[tokio::test]
+    async fn the_handshake_is_acked_with_the_negotiated_variant() {
+        let (transport, _peer) = connected(ClientConfig::default()).await;
+        assert_eq!(transport.session_id(), "s-1");
+        assert_eq!(transport.variant(), Variant::Json);
+        assert_eq!(transport.server_features(), [session::FEATURE_STREAMING]);
+    }
+
+    #[tokio::test]
+    async fn a_foreign_session_id_is_rejected() {
+        // 2.2 step 2: the id must be the one we passed at spawn.
+        let (client_read, client_write, mut peer) = wire();
+        peer.send_control(offer("someone-else", vec![Variant::Json]))
+            .await;
+        let err = StdioTransport::attach(client_read, client_write, "s-1", ClientConfig::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.message.contains("session id mismatch"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn no_common_variant_is_declined_rather_than_dropped() {
+        // 2.2 step 4: without an ack the agent would wait instead of exiting 0.
+        let (client_read, client_write, mut peer) = wire();
+        peer.send_control(offer("s-1", vec![Variant::Proto])).await;
+        let err = StdioTransport::attach(client_read, client_write, "s-1", ClientConfig::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.message.contains("no serialization variant"),
+            "{}",
+            err.message
+        );
+
+        match peer.recv().await {
+            ServerInbound::Control(ControlFrame::HandshakeAck(ack)) => assert!(!ack.accept),
+            other => panic!("expected a declining handshakeAck, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_incompatible_version_keeps_its_own_error_code() {
+        let (client_read, client_write, mut peer) = wire();
+        let mut frame = offer("s-1", vec![Variant::Json]);
+        if let ControlFrame::Handshake(hs) = &mut frame {
+            hs.protocol_version = "2.0".into();
+        }
+        peer.send_control(frame).await;
+        let err = StdioTransport::attach(client_read, client_write, "s-1", ClientConfig::default())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, error_code::VERSION_NOT_SUPPORTED);
+    }
+
+    #[tokio::test]
+    async fn a_method_frame_before_the_handshake_is_refused() {
+        let (client_read, client_write, mut peer) = wire();
+        peer.result(JsonRpcId::Number(1), &sample_task("t-1")).await;
+        let err = StdioTransport::attach(client_read, client_write, "s-1", ClientConfig::default())
+            .await
+            .unwrap_err();
+        assert!(err.message.contains("first frame"), "{}", err.message);
+    }
+
+    // ---- unary calls -----------------------------------------------------
+
+    #[tokio::test]
+    async fn a_unary_call_round_trips() {
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (params, req) = (ServiceParams::new(), get_task("t-1"));
+        let call = transport.get_task(&params, &req);
+        let agent = async {
+            let req = peer.recv_request().await;
+            assert_eq!(req.method, methods::GET_TASK);
+            assert_eq!(req.params.as_ref().unwrap()["id"], json!("t-1"));
+            peer.result(req.id, &sample_task("t-1")).await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        assert_eq!(result.unwrap().id, "t-1");
+    }
+
+    #[tokio::test]
+    async fn concurrent_calls_are_correlated_by_id() {
+        // 3.6: the pipe carries no other association between the two.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let params = ServiceParams::new();
+        let (a_req, b_req) = (get_task("t-a"), get_task("t-b"));
+        let first = transport.get_task(&params, &a_req);
+        let second = transport.get_task(&params, &b_req);
+        let agent = async {
+            let a = peer.recv_request().await;
+            let b = peer.recv_request().await;
+            assert_ne!(a.id, b.id, "each request needs its own id");
+            // Answered in reverse, so ordering cannot stand in for correlation.
+            for req in [b, a] {
+                let asked = req.params.as_ref().unwrap()["id"]
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+                peer.result(req.id, &sample_task(&asked)).await;
+            }
+        };
+        let (a, b, ()) = tokio::join!(first, second, agent);
+        assert_eq!(a.unwrap().id, "t-a");
+        assert_eq!(b.unwrap().id, "t-b");
+    }
+
+    #[tokio::test]
+    async fn service_params_travel_in_the_request_body() {
+        // 4.2: a flat map, with 4.1's comma joining multi-values.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let mut params = ServiceParams::new();
+        params.insert("a2a-extensions".into(), vec!["a".into(), "b".into()]);
+
+        let req = get_task("t-1");
+        let call = transport.get_task(&params, &req);
+        let agent = async {
+            let req = peer.recv_request().await;
+            let sp = req.service_params.clone().expect("serviceParams missing");
+            assert_eq!(sp["a2a-extensions"], "a,b");
+            peer.result(req.id, &sample_task("t-1")).await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_error_frame_keeps_its_a2a_code() {
+        // 7.1 and 7.2: the error object is the JSON-RPC binding's, so the code
+        // has to survive the round trip rather than collapse to INTERNAL_ERROR.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (params, req) = (ServiceParams::new(), get_task("t-1"));
+        let call = transport.get_task(&params, &req);
+        let agent = async {
+            let req = peer.recv_request().await;
+            peer.send(ServerMessage::Error {
+                id: req.id,
+                error: A2AError::task_not_found("t-1").to_jsonrpc_error(),
+            })
+            .await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        let err = result.unwrap_err();
+        assert_eq!(err.code, error_code::TASK_NOT_FOUND);
+        assert!(err.message.contains("t-1"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn a_null_result_satisfies_the_one_method_without_a_body() {
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let req = DeleteTaskPushNotificationConfigRequest {
+            task_id: "t-1".into(),
+            id: "cfg-1".into(),
+            tenant: None,
+        };
+        let params = ServiceParams::new();
+        let call = transport.delete_push_config(&params, &req);
+        let agent = async {
+            let req = peer.recv_request().await;
+            assert_eq!(req.method, methods::DELETE_PUSH_CONFIG);
+            peer.send(ServerMessage::Result {
+                id: req.id,
+                result: Value::Null,
+            })
+            .await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_frame_fails_one_call_and_not_the_session() {
+        // 3.1 forbids failing over content we do not recognize, and 3.4 keeps
+        // the id readable, so only the caller that cannot be answered suffers.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let params = ServiceParams::new();
+
+        let first = get_task("t-1");
+        let call = transport.get_task(&params, &first);
+        let agent = async {
+            let req = peer.recv_request().await;
+            // Valid JSON-RPC, but carrying neither a result nor an error.
+            peer.send_raw(json!({"jsonrpc": "2.0", "id": req.id})).await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        let err = result.unwrap_err();
+        assert!(err.message.contains("cannot read"), "{}", err.message);
+
+        let second = get_task("t-2");
+        let call = transport.get_task(&params, &second);
+        let agent = async {
+            let req = peer.recv_request().await;
+            peer.result(req.id, &sample_task("t-2")).await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        assert_eq!(
+            result.unwrap().id,
+            "t-2",
+            "one bad frame must not end the session"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_frame_without_an_id_is_only_logged() {
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        peer.send_raw(json!(["not", "an", "object"])).await;
+
+        let params = ServiceParams::new();
+        let req = get_task("t-1");
+        let call = transport.get_task(&params, &req);
+        let agent = async {
+            let req = peer.recv_request().await;
+            peer.result(req.id, &sample_task("t-1")).await;
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        result.unwrap();
+    }
+
+    // ---- streaming (8) --------------------------------------------------
+
+    /// Issue a streaming call and hand back the id the agent saw for it.
+    async fn open_stream(
+        transport: &StdioTransport,
+        peer: &mut Peer,
+    ) -> (
+        BoxStream<'static, Result<StreamResponse, A2AError>>,
+        JsonRpcId,
+    ) {
+        let (params, req) = (ServiceParams::new(), subscribe("t-1"));
+        let call = transport.subscribe_to_task(&params, &req);
+        let agent = async { peer.recv_request().await };
+        let (stream, req) = tokio::join!(call, agent);
+        assert_eq!(req.method, methods::SUBSCRIBE_TO_TASK);
+        (stream.unwrap(), req.id)
+    }
+
+    #[tokio::test]
+    async fn a_stream_yields_items_until_stream_end() {
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (mut stream, id) = open_stream(&transport, &mut peer).await;
+
+        peer.result(id.clone(), &StreamResponse::Task(sample_task("t-1")))
+            .await;
+        peer.result(id.clone(), &StreamResponse::Task(sample_task("t-1")))
+            .await;
+        peer.send(ServerMessage::StreamEnd { id }).await;
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(StreamResponse::Task(_)))
+        ));
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(StreamResponse::Task(_)))
+        ));
+        assert!(
+            stream.next().await.is_none(),
+            "streamEnd must end the stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_error_terminates_a_stream_without_a_stream_end() {
+        // 7.3 and 8.3: the error is the last item, and none follows it.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (mut stream, id) = open_stream(&transport, &mut peer).await;
+
+        peer.result(id.clone(), &StreamResponse::Task(sample_task("t-1")))
+            .await;
+        peer.send(ServerMessage::Error {
+            id,
+            error: A2AError::internal("boom").to_jsonrpc_error(),
+        })
+        .await;
+
+        assert!(matches!(stream.next().await, Some(Ok(_))));
+        let err = stream.next().await.expect("error item").unwrap_err();
+        assert_eq!(err.code, error_code::INTERNAL_ERROR);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_a_stream_early_cancels_it() {
+        // 8.5: stop this stream only, and do not touch the task behind it.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (stream, id) = open_stream(&transport, &mut peer).await;
+        drop(stream);
+
+        match peer.recv().await {
+            ServerInbound::Message(ClientMessage::CancelStream { id: cancelled }) => {
+                assert_eq!(cancelled, id);
+            }
+            other => panic!("expected cancelStream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_stream_that_ended_is_not_cancelled() {
+        // Cancelling here would name an id the agent has already forgotten.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (mut stream, id) = open_stream(&transport, &mut peer).await;
+        peer.send(ServerMessage::StreamEnd { id }).await;
+        assert!(stream.next().await.is_none());
+        drop(stream);
+
+        // `destroy` closes STDIN, so EOF proves nothing else was written.
+        let (result, ()) = tokio::join!(transport.destroy(), async {
+            match peer.recv().await {
+                ServerInbound::Message(ClientMessage::Request(r)) => {
+                    assert_eq!(r.method, json::SYSTEM_SHUTDOWN);
+                }
+                other => panic!("expected only system/shutdown, got {other:?}"),
+            }
+            assert!(peer.reader.next().await.is_none(), "STDIN should be closed");
+        });
+        result.unwrap();
+    }
+
+    // ---- session end (2.4, 8.3) ---------------------------------------
+
+    #[tokio::test]
+    async fn losing_the_agent_fails_a_waiting_call() {
+        let (transport, peer) = connected(ClientConfig::default()).await;
+        let (params, req) = (ServiceParams::new(), get_task("t-1"));
+        let call = transport.get_task(&params, &req);
+        let agent = async {
+            let mut peer = peer;
+            peer.recv_request().await;
+            // The agent exits without answering, which the client sees as EOF.
+            drop(peer);
+        };
+        let (result, ()) = tokio::join!(call, agent);
+        let err = result.unwrap_err();
+        assert!(err.message.contains("closed STDOUT"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn losing_the_agent_ends_an_open_stream() {
+        // 8.3: process exit terminates every active stream.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (mut stream, _) = open_stream(&transport, &mut peer).await;
+        drop(peer);
+
+        let err = stream.next().await.expect("an ending reason").unwrap_err();
+        assert!(err.message.contains("closed STDOUT"), "{}", err.message);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn destroy_asks_politely_then_closes_stdin() {
+        // 2.4: `system/shutdown` first, then EOF, which is the part that binds.
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let agent = async {
+            match peer.recv().await {
+                ServerInbound::Message(ClientMessage::Request(r)) => {
+                    assert_eq!(r.method, json::SYSTEM_SHUTDOWN);
+                }
+                other => panic!("expected system/shutdown, got {other:?}"),
+            }
+            assert!(peer.reader.next().await.is_none(), "STDIN should be closed");
+        };
+        let (result, ()) = tokio::join!(transport.destroy(), agent);
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn destroy_can_skip_the_shutdown_request() {
+        let config = ClientConfig {
+            send_shutdown_request: false,
+            ..ClientConfig::default()
+        };
+        let (transport, mut peer) = connected(config).await;
+        let (result, ()) = tokio::join!(transport.destroy(), async {
+            assert!(peer.reader.next().await.is_none(), "expected only EOF");
+        });
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn calls_after_destroy_fail_instead_of_hanging() {
+        let (transport, mut peer) = connected(ClientConfig::default()).await;
+        let (result, ()) = tokio::join!(transport.destroy(), async {
+            while peer.reader.next().await.is_some() {}
+        });
+        result.unwrap();
+
+        let err = transport
+            .get_task(&ServiceParams::new(), &get_task("t-1"))
+            .await
+            .unwrap_err();
+        assert!(err.message.contains("closed"), "{}", err.message);
+    }
+
+    // ---- launch (2.1, 4.1, 13) ---------------------------------------
+
+    fn explicit_envs(cmd: &Command) -> Vec<(String, String)> {
+        cmd.as_std()
+            .get_envs()
+            .filter_map(|(k, v)| Some((k.to_str()?.to_string(), v?.to_str()?.to_string())))
+            .collect()
+    }
+
+    #[test]
+    fn launch_keeps_arguments_as_a_vector() {
+        // 13.1: the shell metacharacters below stay one opaque argument,
+        // because nothing ever concatenates them into a command line.
+        let cmd = Launch::new("/usr/local/bin/agent")
+            .arg("--serve")
+            .arg("; rm -rf /")
+            .build();
+        let std = cmd.as_std();
+        assert_eq!(std.get_program(), "/usr/local/bin/agent");
+        let args: Vec<_> = std.get_args().collect();
+        assert_eq!(args, ["--serve", "; rm -rf /"]);
+    }
+
+    #[test]
+    fn launch_always_passes_a_session_id() {
+        // 2.1 makes it REQUIRED, and 2.2 negotiates against it.
+        let envs = explicit_envs(&Launch::new("/bin/agent").build());
+        let id = envs
+            .iter()
+            .find(|(k, _)| k == session::ENV_SESSION_ID)
+            .map(|(_, v)| v.clone())
+            .expect("A2A_SESSION_ID missing");
+        assert!(uuid::Uuid::parse_str(&id).is_ok(), "not a uuid: {id}");
+    }
+
+    #[test]
+    fn launch_exports_service_params_the_agent_can_read_back() {
+        // 4.1, checked against the server-side parser rather than a literal.
+        let mut params = ServiceParams::new();
+        params.insert("a2a-extensions".into(), vec!["a".into(), "b".into()]);
+        params.insert("a2a-version".into(), vec!["1.0".into()]);
+
+        let cmd = Launch::new("/bin/agent").service_params(&params).build();
+        let parsed = session::service_params_from_env(explicit_envs(&cmd));
+        assert_eq!(parsed["a2a-extensions"], vec!["a", "b"]);
+        assert_eq!(parsed["a2a-version"], vec!["1.0"]);
+    }
+
+    #[test]
+    fn launch_sets_the_optional_startup_context() {
+        let cmd = Launch::new("/bin/agent")
+            .protocol_version("1.0")
+            .log_level("debug")
+            .build();
+        let envs = explicit_envs(&cmd);
+        assert!(envs.contains(&(session::ENV_PROTOCOL_VERSION.into(), "1.0".into())));
+        assert!(envs.contains(&(session::ENV_LOG_LEVEL.into(), "debug".into())));
+    }
+
+    #[test]
+    fn each_launch_gets_its_own_session_id() {
+        let a = Launch::new("/bin/agent").session_id("fixed");
+        assert_eq!(a.session_id, "fixed");
+        assert_ne!(
+            Launch::new("/bin/agent").session_id,
+            Launch::new("/bin/agent").session_id
+        );
+    }
+}

--- a/a2a-stdio/src/codec.rs
+++ b/a2a-stdio/src/codec.rs
@@ -1,0 +1,250 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use crate::frame::Frame;
+use crate::frame::FrameHeaders;
+use crate::frame::State;
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+pub const DEFAULT_MAX_FRAME_SIZE: usize = 1024 * 1024; // 3.7 recommends 1 MiB
+pub const DEFAULT_MAX_HEADER_SIZE: usize = 8 * 1024; // not in spec; see note below
+pub const HEADER_SIZE_ESTIMATE: usize = 128;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StdioCodecError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error), // From<io::Error> is REQUIRED by Decoder
+    #[error("missing content length")]
+    MissingContentLength,
+    #[error("invalid content length: {0}")]
+    InvalidContentLength(String),
+    #[error("frame too large: {len} > {max}")]
+    FrameTooLarge { len: usize, max: usize },
+    #[error("header block too large: {max}")]
+    HeaderBlockTooLarge { max: usize },
+    #[error("malformed header: {0}")]
+    MalformedHeader(String),
+    #[error("unexpected end of input")]
+    UnexpectedEndOfInput,
+}
+
+pub struct StdioCodec {
+    state: State,
+    scanned: usize, // how far we've already searched for \r\n\r\n
+    max_frame_size: usize,
+    max_header_size: usize,
+}
+
+impl StdioCodec {
+    pub fn new(max_frame_size: usize, max_header_size: usize) -> Self {
+        Self {
+            state: State::Headers,
+            scanned: 0,
+            max_frame_size,
+            max_header_size,
+        }
+    }
+}
+
+impl Decoder for StdioCodec {
+    type Item = Frame;
+    type Error = StdioCodecError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Frame>, Self::Error> {
+        loop {
+            match &mut self.state {
+                State::Headers => {
+                    let Some(i) = find_separator(src, self.scanned) else {
+                        if src.len() > self.max_header_size {
+                            return Err(StdioCodecError::HeaderBlockTooLarge {
+                                max: self.max_header_size,
+                            });
+                        }
+                        self.scanned = src.len().saturating_sub(3);
+                        return Ok(None);
+                    };
+                    let (content_length, headers) = parse_headers(&src[..i])?;
+                    if content_length > self.max_frame_size {
+                        return Err(StdioCodecError::FrameTooLarge {
+                            len: content_length,
+                            max: self.max_frame_size,
+                        });
+                    }
+                    src.advance(i + 4);
+                    self.scanned = 0;
+                    self.state = State::Body {
+                        content_length,
+                        headers,
+                    };
+                }
+                State::Body {
+                    content_length,
+                    headers,
+                } => {
+                    let content_length = *content_length;
+                    if src.len() < content_length {
+                        src.reserve(content_length - src.len());
+                        return Ok(None);
+                    }
+                    let headers = std::mem::take(headers);
+                    let body = src.split_to(content_length).freeze();
+                    self.state = State::Headers;
+                    return Ok(Some(Frame { headers, body }));
+                }
+            }
+        }
+    }
+}
+
+impl Encoder<Frame> for StdioCodec {
+    type Error = StdioCodecError;
+
+    fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let n = item.body.len();
+        if n > self.max_frame_size {
+            return Err(StdioCodecError::FrameTooLarge {
+                len: n,
+                max: self.max_frame_size,
+            });
+        }
+
+        // Reject CRLF in any peer-influenced header text before writing a single
+        // byte: a stray \r\n would inject headers or split the frame, and `dst`
+        // is a shared buffer with no rollback once written.
+        let h = &item.headers;
+        for text in [
+            h.content_type.as_deref(),
+            h.a2a_kind.as_deref(),
+            h.a2a_id.as_deref(),
+            h.a2a_method.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .chain(h.service_params.keys().map(String::as_str))
+        .chain(h.service_params.values().flatten().map(String::as_str))
+        {
+            if text.contains(['\r', '\n']) {
+                return Err(StdioCodecError::MalformedHeader(text.to_owned()));
+            }
+        }
+
+        dst.reserve(HEADER_SIZE_ESTIMATE + 2 + n);
+
+        // Everything from here is append-only, so `truncate(header_start)` is an
+        // exact rollback if the header block turns out to be over the limit.
+        let header_start = dst.len();
+        put_header(dst, "Content-Length", &n.to_string());
+        if let Some(v) = h.content_type.as_deref() {
+            put_header(dst, "Content-Type", v);
+        }
+        if let Some(v) = h.a2a_kind.as_deref() {
+            put_header(dst, "A2A-Kind", v);
+        }
+        if let Some(v) = h.a2a_id.as_deref() {
+            put_header(dst, "A2A-Id", v);
+        }
+        if let Some(v) = h.a2a_method.as_deref() {
+            put_header(dst, "A2A-Method", v);
+        }
+        // One `A2A-SP-<name>: <value>` line per value (15.2).
+        for (key, values) in &h.service_params {
+            for value in values {
+                put_header(dst, &format!("A2A-SP-{key}"), value);
+            }
+        }
+        dst.extend_from_slice(b"\r\n");
+
+        if dst.len() - header_start > self.max_header_size {
+            dst.truncate(header_start);
+            return Err(StdioCodecError::HeaderBlockTooLarge {
+                max: self.max_header_size,
+            });
+        }
+
+        dst.extend_from_slice(&item.body);
+
+        Ok(())
+    }
+}
+
+/// Parse a frame's header block (3.1, 15.2), returning `Content-Length` and
+/// the recognised headers.
+///
+/// Header names are compared case-insensitively per RFC 7230. Unrecognised
+/// headers are ignored. `Content-Length` is the only required header.
+fn parse_headers(block: &[u8]) -> Result<(usize, FrameHeaders), StdioCodecError> {
+    let block = std::str::from_utf8(block)
+        .map_err(|e| StdioCodecError::MalformedHeader(format!("not valid UTF-8: {e}")))?;
+
+    let mut content_length: Option<usize> = None;
+    let mut headers = FrameHeaders::default();
+
+    for line in block.split("\r\n") {
+        if line.is_empty() {
+            continue;
+        }
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| StdioCodecError::MalformedHeader(line.to_owned()))?;
+        // RFC 7230 forbids whitespace between the field name and the colon, and
+        // a leading-whitespace line is deprecated obs-fold. Tolerating either
+        // creates parser disagreements, so reject rather than trim.
+        if name.trim() != name {
+            return Err(StdioCodecError::MalformedHeader(line.to_owned()));
+        }
+        let value = value.trim();
+
+        if name.eq_ignore_ascii_case("content-length") {
+            let len = value
+                .parse::<usize>()
+                .map_err(|_| StdioCodecError::InvalidContentLength(value.to_owned()))?;
+            content_length = Some(len);
+        } else if name.eq_ignore_ascii_case("content-type") {
+            headers.content_type = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case("a2a-kind") {
+            headers.a2a_kind = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case("a2a-id") {
+            headers.a2a_id = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case("a2a-method") {
+            headers.a2a_method = Some(value.to_owned());
+        } else if let Some(key) = strip_prefix_ignore_ascii_case(name, "a2a-sp-") {
+            headers
+                .service_params
+                .entry(key.to_ascii_lowercase())
+                .or_default()
+                .push(value.to_owned());
+        }
+    }
+
+    let content_length = content_length.ok_or(StdioCodecError::MissingContentLength)?;
+    Ok((content_length, headers))
+}
+
+/// Case-insensitive [`str::strip_prefix`]. Returns `None` if `prefix` does not
+/// match or does not end on a character boundary.
+fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    let (head, rest) = s.split_at_checked(prefix.len())?;
+    head.eq_ignore_ascii_case(prefix).then_some(rest)
+}
+
+/// Locate the `\r\n\r\n` header/body separator (3.1), resuming at `from`.
+///
+/// Returns the offset of the separator's first byte, which is also the length
+/// of the header block. `from` lets the caller skip bytes already searched in a
+/// previous poll; it is clamped so a separator straddling two reads is not missed.
+fn find_separator(src: &[u8], from: usize) -> Option<usize> {
+    const SEP: &[u8] = b"\r\n\r\n";
+    let last_start = src.len().checked_sub(SEP.len())?;
+    let start = from.min(last_start);
+    src[start..]
+        .windows(SEP.len())
+        .position(|w| w == SEP)
+        .map(|i| start + i)
+}
+
+fn put_header(dst: &mut BytesMut, name: &str, value: &str) {
+    dst.extend_from_slice(name.as_bytes());
+    dst.extend_from_slice(b": ");
+    dst.extend_from_slice(value.as_bytes());
+    dst.extend_from_slice(b"\r\n");
+}

--- a/a2a-stdio/src/frame.rs
+++ b/a2a-stdio/src/frame.rs
@@ -1,0 +1,29 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Closed set per 3.1 and 15.2. Unknown headers are dropped (RFC 7230).
+use bytes::Bytes;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FrameHeaders {
+    pub content_type: Option<String>,
+    pub a2a_kind: Option<String>, // request|response|error|stream|streamEnd|cancel
+    pub a2a_id: Option<String>,
+    pub a2a_method: Option<String>,
+    pub service_params: HashMap<String, Vec<String>>, // from A2A-SP-*
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Frame {
+    pub headers: FrameHeaders,
+    pub body: Bytes, // exactly Content-Length bytes; may be empty
+}
+
+pub enum State {
+    Headers,
+    Body {
+        content_length: usize,
+        headers: FrameHeaders,
+    },
+}

--- a/a2a-stdio/src/json.rs
+++ b/a2a-stdio/src/json.rs
@@ -1,0 +1,524 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Message layer for the `stdio-json` variant (3, 4.2, 8.5).
+//!
+//! The frames here are JSON-RPC 2.0 objects plus three A2A extension members:
+//! `serviceParams`, `streamEnd` and `cancelStream`. Per 3.1, unrecognized
+//! members must be ignored rather than rejected, so nothing in this module uses
+//! `deny_unknown_fields`.
+
+use std::collections::HashMap;
+
+use a2a::jsonrpc::{JsonRpcError, JsonRpcId};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::wire::{ControlFrame, WireError};
+
+pub const JSONRPC_VERSION: &str = "2.0";
+
+/// Shutdown request defined by this binding only; absent from `a2a::methods` (6.9).
+pub const SYSTEM_SHUTDOWN: &str = "system/shutdown";
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// A JSON-RPC request carrying the optional `serviceParams` extension (3.2, 4.2).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StdioRequest {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    /// 4.2 defines this as a flat map; multi-value params are comma separated (4.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_params: Option<HashMap<String, String>>,
+}
+
+impl StdioRequest {
+    pub fn new(id: JsonRpcId, method: impl Into<String>, params: Option<Value>) -> Self {
+        StdioRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            method: method.into(),
+            params,
+            service_params: None,
+        }
+    }
+
+    pub fn with_service_params(mut self, sp: &HashMap<String, Vec<String>>) -> Self {
+        self.service_params = if sp.is_empty() {
+            None
+        } else {
+            Some(service_params_to_wire(sp))
+        };
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClientMessage {
+    Request(StdioRequest),
+    CancelStream { id: JsonRpcId },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServerMessage {
+    /// A unary response and a stream chunk are byte-identical here; the reader
+    /// tells them apart from the method it issued for this id (3.5).
+    Result {
+        id: JsonRpcId,
+        result: Value,
+    },
+    Error {
+        id: JsonRpcId,
+        error: JsonRpcError,
+    },
+    StreamEnd {
+        id: JsonRpcId,
+    },
+}
+
+/// What a server may read off `STDIN`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServerInbound {
+    Control(ControlFrame),
+    Message(ClientMessage),
+}
+
+/// What a client may read off the child's `STDOUT`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClientInbound {
+    Control(ControlFrame),
+    Message(ServerMessage),
+}
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+//
+// One struct per distinguishable frame layout, used for both directions so that
+// serde performs the member extraction instead of hand-indexing a `Value`.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResultFrame {
+    jsonrpc: String,
+    id: JsonRpcId,
+    result: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ErrorFrame {
+    jsonrpc: String,
+    id: JsonRpcId,
+    error: JsonRpcError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamEndFrame {
+    jsonrpc: String,
+    id: JsonRpcId,
+    stream_end: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CancelStreamFrame {
+    jsonrpc: String,
+    id: JsonRpcId,
+    cancel_stream: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+impl ClientMessage {
+    pub fn to_value(&self) -> Result<Value, serde_json::Error> {
+        match self {
+            ClientMessage::Request(req) => serde_json::to_value(req),
+            ClientMessage::CancelStream { id } => serde_json::to_value(CancelStreamFrame {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: id.clone(),
+                cancel_stream: true,
+            }),
+        }
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.to_value()?)
+    }
+}
+
+impl ServerMessage {
+    pub fn to_value(&self) -> Result<Value, serde_json::Error> {
+        match self {
+            ServerMessage::Result { id, result } => serde_json::to_value(ResultFrame {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: id.clone(),
+                result: result.clone(),
+            }),
+            ServerMessage::Error { id, error } => serde_json::to_value(ErrorFrame {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: id.clone(),
+                error: error.clone(),
+            }),
+            ServerMessage::StreamEnd { id } => serde_json::to_value(StreamEndFrame {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: id.clone(),
+                stream_end: true,
+            }),
+        }
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.to_value()?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+/// Cheap read-only classification of a frame body.
+///
+/// Everything captured here is owned, so the borrow of the parsed `Value` ends
+/// when `Peek::new` returns and the caller stays free to move that `Value` into
+/// `serde_json::from_value`.
+struct Peek {
+    is_control: bool,
+    version: Option<String>,
+    has_method: bool,
+    has_result: bool,
+    has_error: bool,
+    cancel_stream: bool,
+    stream_end: bool,
+}
+
+impl Peek {
+    fn new(v: &Value) -> Result<Self, WireError> {
+        let obj = v.as_object().ok_or(WireError::NotAnObject)?;
+        Ok(Peek {
+            is_control: obj.contains_key("type"),
+            version: obj
+                .get("jsonrpc")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            has_method: obj.contains_key("method"),
+            has_result: obj.contains_key("result"),
+            has_error: obj.contains_key("error"),
+            cancel_stream: flag(obj, "cancelStream"),
+            stream_end: flag(obj, "streamEnd"),
+        })
+    }
+
+    fn require_jsonrpc_2(&self) -> Result<(), WireError> {
+        if self.version.as_deref() == Some(JSONRPC_VERSION) {
+            Ok(())
+        } else {
+            Err(WireError::BadVersion(
+                self.version.clone().unwrap_or_default(),
+            ))
+        }
+    }
+}
+
+fn flag(obj: &Map<String, Value>, key: &str) -> bool {
+    obj.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// Best-effort request id for a body whose shape was rejected. 3.4 reserves the
+/// null id for frames whose id genuinely could not be determined.
+pub fn peek_id(body: &[u8]) -> JsonRpcId {
+    let Ok(v) = serde_json::from_slice::<Value>(body) else {
+        return JsonRpcId::Null;
+    };
+    match v.get("id") {
+        Some(id) => serde_json::from_value(id.clone()).unwrap_or(JsonRpcId::Null),
+        None => JsonRpcId::Null,
+    }
+}
+
+/// Classify a frame body sent by a client, i.e. what a server reads.
+pub fn parse_from_client(body: &[u8]) -> Result<ServerInbound, WireError> {
+    let v: Value = serde_json::from_slice(body)?;
+    let peek = Peek::new(&v)?;
+
+    // Control frames carry no `jsonrpc` member, so they must be routed before
+    // the version check (2.2).
+    if peek.is_control {
+        return Ok(ServerInbound::Control(serde_json::from_value(v)?));
+    }
+    peek.require_jsonrpc_2()?;
+
+    if peek.has_method {
+        let req: StdioRequest = serde_json::from_value(v)?;
+        return Ok(ServerInbound::Message(ClientMessage::Request(req)));
+    }
+    if peek.cancel_stream {
+        let f: CancelStreamFrame = serde_json::from_value(v)?;
+        return Ok(ServerInbound::Message(ClientMessage::CancelStream {
+            id: f.id,
+        }));
+    }
+    Err(WireError::UnrecognizedMessage)
+}
+
+/// Classify a frame body sent by a server, i.e. what a client reads.
+pub fn parse_from_server(body: &[u8]) -> Result<ClientInbound, WireError> {
+    let v: Value = serde_json::from_slice(body)?;
+    let peek = Peek::new(&v)?;
+
+    if peek.is_control {
+        return Ok(ClientInbound::Control(serde_json::from_value(v)?));
+    }
+    peek.require_jsonrpc_2()?;
+
+    // Error wins over result, and streamEnd over both: a peer that sends more
+    // than one of them is read the conservative way.
+    if peek.has_error {
+        let f: ErrorFrame = serde_json::from_value(v)?;
+        return Ok(ClientInbound::Message(ServerMessage::Error {
+            id: f.id,
+            error: f.error,
+        }));
+    }
+    if peek.stream_end {
+        let f: StreamEndFrame = serde_json::from_value(v)?;
+        return Ok(ClientInbound::Message(ServerMessage::StreamEnd {
+            id: f.id,
+        }));
+    }
+    if peek.has_result {
+        let f: ResultFrame = serde_json::from_value(v)?;
+        return Ok(ClientInbound::Message(ServerMessage::Result {
+            id: f.id,
+            result: f.result,
+        }));
+    }
+    Err(WireError::UnrecognizedMessage)
+}
+
+// ---------------------------------------------------------------------------
+// Service parameters
+//
+// 4.2 carries them as a flat map in the body, while `ServiceParams` elsewhere
+// in the SDK is multi-valued. 4.1 makes comma the separator.
+// ---------------------------------------------------------------------------
+
+pub fn wire_to_service_params(m: &HashMap<String, String>) -> HashMap<String, Vec<String>> {
+    let mut result = HashMap::new();
+    for (k, v) in m {
+        let values: Vec<String> = v
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        result.insert(k.to_ascii_lowercase(), values);
+    }
+    result
+}
+
+pub fn service_params_to_wire(sp: &HashMap<String, Vec<String>>) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for (k, vs) in sp {
+        result.insert(k.to_ascii_lowercase(), vs.join(","));
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::{Handshake, Variant};
+    use serde_json::json;
+
+    fn bytes(v: Value) -> Vec<u8> {
+        serde_json::to_vec(&v).unwrap()
+    }
+
+    #[test]
+    fn unknown_members_are_ignored() {
+        // 3.1: unrecognized extension members must not fail the message.
+        let body = bytes(json!({
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "SendMessage",
+            "futureExtension": {"anything": true},
+        }));
+        match parse_from_client(&body).unwrap() {
+            ServerInbound::Message(ClientMessage::Request(r)) => {
+                assert_eq!(r.method, "SendMessage");
+            }
+            other => panic!("expected request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absent_service_params_are_not_serialized() {
+        let req = StdioRequest::new(JsonRpcId::Number(1), "GetTask", None);
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(!s.contains("serviceParams"), "got {s}");
+        assert!(!s.contains("params"), "got {s}");
+    }
+
+    #[test]
+    fn service_params_use_camel_case_on_the_wire() {
+        let mut sp = HashMap::new();
+        sp.insert("a2a-version".to_string(), vec!["1.0".to_string()]);
+        let req = StdioRequest::new(JsonRpcId::Number(1), "GetTask", None).with_service_params(&sp);
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["serviceParams"]["a2a-version"], json!("1.0"));
+    }
+
+    #[test]
+    fn variant_uses_hyphenated_names() {
+        assert_eq!(
+            serde_json::to_value(Variant::Json).unwrap(),
+            json!("stdio-json")
+        );
+        assert_eq!(
+            serde_json::to_value(Variant::Proto).unwrap(),
+            json!("stdio-proto")
+        );
+    }
+
+    #[test]
+    fn handshake_round_trips_with_camel_case_keys() {
+        let hs = Handshake {
+            protocol: "a2a-stdio".into(),
+            protocol_version: "1.0".into(),
+            session_id: "s-1".into(),
+            supported_variants: vec![Variant::Json, Variant::Proto],
+            features: vec!["streaming".into()],
+            pid: Some(42137),
+        };
+        let v = serde_json::to_value(ControlFrame::Handshake(hs.clone())).unwrap();
+        assert_eq!(v["type"], json!("handshake"));
+        assert_eq!(v["protocolVersion"], json!("1.0"));
+        assert_eq!(v["sessionId"], json!("s-1"));
+        assert_eq!(v["supportedVariants"], json!(["stdio-json", "stdio-proto"]));
+
+        let body = serde_json::to_vec(&v).unwrap();
+        match parse_from_server(&body).unwrap() {
+            ClientInbound::Control(ControlFrame::Handshake(back)) => assert_eq!(back, hs),
+            other => panic!("expected handshake, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_end_is_not_read_as_a_result() {
+        let body = bytes(json!({"jsonrpc": "2.0", "id": "req-1", "streamEnd": true}));
+        match parse_from_server(&body).unwrap() {
+            ClientInbound::Message(ServerMessage::StreamEnd { id }) => {
+                assert_eq!(id, JsonRpcId::String("req-1".into()));
+            }
+            other => panic!("expected streamEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_wins_over_result() {
+        let body = bytes(json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {"ignored": true},
+            "error": {"code": -32603, "message": "boom"},
+        }));
+        match parse_from_server(&body).unwrap() {
+            ClientInbound::Message(ServerMessage::Error { error, .. }) => {
+                assert_eq!(error.code, -32603);
+            }
+            other => panic!("expected error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_stream_round_trips() {
+        let msg = ClientMessage::CancelStream {
+            id: JsonRpcId::String("req-1".into()),
+        };
+        let v = msg.to_value().unwrap();
+        assert_eq!(v["cancelStream"], json!(true));
+
+        let body = serde_json::to_vec(&v).unwrap();
+        match parse_from_client(&body).unwrap() {
+            ServerInbound::Message(ClientMessage::CancelStream { id }) => {
+                assert_eq!(id, JsonRpcId::String("req-1".into()));
+            }
+            other => panic!("expected cancelStream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_object_is_an_error_not_a_panic() {
+        let err = parse_from_client(&bytes(json!({}))).unwrap_err();
+        assert!(matches!(err, WireError::BadVersion(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn non_object_bodies_are_rejected() {
+        assert!(matches!(
+            parse_from_client(&bytes(json!([1, 2, 3]))).unwrap_err(),
+            WireError::NotAnObject
+        ));
+    }
+
+    #[test]
+    fn unknown_control_frame_type_is_rejected() {
+        let body = bytes(json!({"type": "somethingElse", "sessionId": "s-1"}));
+        assert!(matches!(
+            parse_from_client(&body).unwrap_err(),
+            WireError::Json(_)
+        ));
+    }
+
+    #[test]
+    fn wrong_jsonrpc_version_is_rejected() {
+        let body = bytes(json!({"jsonrpc": "1.0", "id": 1, "method": "GetTask"}));
+        match parse_from_client(&body).unwrap_err() {
+            WireError::BadVersion(v) => assert_eq!(v, "1.0"),
+            other => panic!("expected BadVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn well_formed_but_unclassifiable_message_is_rejected() {
+        let body = bytes(json!({"jsonrpc": "2.0", "id": 1}));
+        assert!(matches!(
+            parse_from_client(&body).unwrap_err(),
+            WireError::UnrecognizedMessage
+        ));
+    }
+
+    #[test]
+    fn service_params_split_and_join_round_trip() {
+        let mut wire = HashMap::new();
+        wire.insert("a2a-extensions".to_string(), "a, b ,c".to_string());
+        let multi = wire_to_service_params(&wire);
+        assert_eq!(multi["a2a-extensions"], vec!["a", "b", "c"]);
+        assert_eq!(service_params_to_wire(&multi)["a2a-extensions"], "a,b,c");
+    }
+
+    #[test]
+    fn service_param_keys_are_lowercased() {
+        let mut wire = HashMap::new();
+        wire.insert("A2A-Version".to_string(), "1.0".to_string());
+        assert!(wire_to_service_params(&wire).contains_key("a2a-version"));
+    }
+
+    #[test]
+    fn empty_service_param_values_are_dropped() {
+        let mut wire = HashMap::new();
+        wire.insert("k".to_string(), " , ,".to_string());
+        assert!(wire_to_service_params(&wire)["k"].is_empty());
+    }
+}

--- a/a2a-stdio/src/lib.rs
+++ b/a2a-stdio/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+pub mod client;
+pub mod codec;
+pub mod frame;
+pub mod json;
+pub mod metadata;
+pub mod server;
+pub mod session;
+pub mod wire;

--- a/a2a-stdio/src/metadata.rs
+++ b/a2a-stdio/src/metadata.rs
@@ -1,0 +1,268 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session binding stamped into emitted output (9.6).
+//!
+//! 9.5 splits local runtime facts from durable proof, and 9.6 keeps the former
+//! inspectable after a result leaves the process by recording which spawn
+//! produced it. These are local-scope facts only: a consumer may correlate them
+//! with a spawn but must not read them as cross-host identity.
+
+use serde_json::{Map, Value};
+
+use crate::wire::Variant;
+
+/// 9.6 metadata key, provisional until the binding is registered.
+pub const BINDING_URI: &str = "https://a2a-protocol.org/bindings/stdio/v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionBinding {
+    pub session_id: String,
+    pub pid: Option<u32>,
+    pub variant: Variant,
+    /// Digest the host computed over the launch descriptor. 9.6 forbids
+    /// secrets or raw environment values here.
+    pub launch_digest: Option<String>,
+}
+
+impl SessionBinding {
+    /// 9.6 wants `sessionId` and `pid`, and permits `variant` and
+    /// `launchDigest`. Absent optionals are omitted rather than sent as null.
+    pub fn to_value(&self) -> Value {
+        let mut out = Map::new();
+        out.insert(
+            "sessionId".to_string(),
+            Value::String(self.session_id.clone()),
+        );
+        if let Some(pid) = self.pid {
+            out.insert("pid".to_string(), Value::Number(pid.into()));
+        }
+        out.insert(
+            "variant".to_string(),
+            Value::String(self.variant.as_str().to_string()),
+        );
+        if let Some(digest) = &self.launch_digest {
+            out.insert("launchDigest".to_string(), Value::String(digest.clone()));
+        }
+        Value::Object(out)
+    }
+}
+
+/// Stamp `binding` into every `Task`, `Message` and `Artifact` in a response.
+///
+/// The walk ignores container shape, so nested artifacts, history and stream
+/// events are all reached without this module knowing any response layout. An
+/// existing entry is never replaced: `Task.history` can outlive a spawn (8.4),
+/// and restamping it would credit this session with older output.
+pub fn stamp(value: &mut Value, binding: &Value) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                stamp(item, binding);
+            }
+        }
+        Value::Object(map) => {
+            for nested in map.values_mut() {
+                stamp(nested, binding);
+            }
+            if !is_emitted_object(map) {
+                return;
+            }
+            let slot = map
+                .entry("metadata")
+                .or_insert_with(|| Value::Object(Map::new()));
+            // ProtoJSON may render an absent Struct as null rather than omit it.
+            if slot.is_null() {
+                *slot = Value::Object(Map::new());
+            }
+            if let Value::Object(metadata) = slot {
+                metadata
+                    .entry(BINDING_URI)
+                    .or_insert_with(|| binding.clone());
+            }
+        }
+        _ => {}
+    }
+}
+
+/// 9.6 names exactly three emitted types, and each key here belongs to only one
+/// message in `a2a.proto`. `contextId`, `role` and `parts` are deliberately not
+/// required: ProtoJSON omits proto3 defaults, so any of them may be absent.
+/// `status` pairs with `id` because the update events carry `taskId` instead.
+fn is_emitted_object(map: &Map<String, Value>) -> bool {
+    map.contains_key("messageId")
+        || map.contains_key("artifactId")
+        || (map.contains_key("id") && map.contains_key("status"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a::{Artifact, Message, Role, Task, TaskState, TaskStatus};
+    use serde_json::json;
+
+    fn binding() -> Value {
+        SessionBinding {
+            session_id: "s-1".into(),
+            pid: Some(42137),
+            variant: Variant::Json,
+            launch_digest: None,
+        }
+        .to_value()
+    }
+
+    fn stamped(value: &Value) -> &Value {
+        &value["metadata"][BINDING_URI]
+    }
+
+    #[test]
+    fn variant_token_matches_the_serde_rename() {
+        for v in [Variant::Json, Variant::Proto] {
+            assert_eq!(serde_json::to_value(v).unwrap(), json!(v.as_str()));
+        }
+    }
+
+    #[test]
+    fn binding_omits_absent_optionals() {
+        let v = SessionBinding {
+            session_id: "s-1".into(),
+            pid: None,
+            variant: Variant::Proto,
+            launch_digest: None,
+        }
+        .to_value();
+        assert_eq!(v, json!({"sessionId": "s-1", "variant": "stdio-proto"}));
+    }
+
+    #[test]
+    fn binding_carries_pid_and_digest_when_known() {
+        let v = SessionBinding {
+            session_id: "s-1".into(),
+            pid: Some(7),
+            variant: Variant::Json,
+            launch_digest: Some("sha256:abc".into()),
+        }
+        .to_value();
+        assert_eq!(v["pid"], json!(7));
+        assert_eq!(v["launchDigest"], json!("sha256:abc"));
+    }
+
+    /// The discriminators are guesses about ProtoJSON unless a real payload
+    /// proves them, so this builds one through the same conversion the server
+    /// uses and checks every nesting level 9.6 mentions.
+    #[test]
+    fn a_real_protojson_task_is_stamped_at_every_level() {
+        let task = Task {
+            id: "t-1".into(),
+            context_id: "c-1".into(),
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: Some(Message::new(Role::Agent, vec![])),
+                timestamp: None,
+            },
+            artifacts: Some(vec![Artifact {
+                artifact_id: "a-1".into(),
+                name: None,
+                description: None,
+                parts: vec![],
+                metadata: None,
+                extensions: None,
+            }]),
+            history: Some(vec![Message::new(Role::User, vec![])]),
+            metadata: None,
+        };
+        let mut v = a2a_pb::protojson_conv::to_value(&task).expect("task converts to ProtoJSON");
+
+        stamp(&mut v, &binding());
+
+        assert_eq!(stamped(&v)["sessionId"], json!("s-1"));
+        assert_eq!(stamped(&v)["pid"], json!(42137));
+        assert_eq!(stamped(&v["artifacts"][0])["sessionId"], json!("s-1"));
+        assert_eq!(stamped(&v["history"][0])["sessionId"], json!("s-1"));
+        assert_eq!(
+            stamped(&v["status"]["message"])["sessionId"],
+            json!("s-1"),
+            "the message inside a status is emitted too"
+        );
+    }
+
+    #[test]
+    fn update_events_are_not_mistaken_for_tasks() {
+        // 9.6 names Task, Message and Artifact only. A status update carries
+        // `taskId` and `status`, which must not look like a task.
+        let mut v = json!({
+            "taskId": "t-1",
+            "contextId": "c-1",
+            "status": {"state": "TASK_STATE_WORKING"},
+        });
+        stamp(&mut v, &binding());
+        assert!(v.get("metadata").is_none(), "got {v}");
+    }
+
+    #[test]
+    fn an_artifact_inside_an_update_event_is_still_stamped() {
+        let mut v = json!({
+            "taskId": "t-1",
+            "contextId": "c-1",
+            "artifact": {"artifactId": "a-1", "parts": []},
+        });
+        stamp(&mut v, &binding());
+        assert_eq!(stamped(&v["artifact"])["sessionId"], json!("s-1"));
+        assert!(v.get("metadata").is_none(), "the event itself is untouched");
+    }
+
+    #[test]
+    fn an_existing_binding_is_left_alone() {
+        // 8.4 respawn: history can predate this session, so whatever stamped it
+        // first stays.
+        let older = json!({"sessionId": "s-0", "pid": 1});
+        let mut v = json!({
+            "id": "t-1",
+            "status": {"state": "TASK_STATE_COMPLETED"},
+            "metadata": {BINDING_URI: older.clone()},
+        });
+        stamp(&mut v, &binding());
+        assert_eq!(*stamped(&v), older);
+    }
+
+    #[test]
+    fn unrelated_metadata_survives() {
+        let mut v = json!({
+            "messageId": "m-1",
+            "metadata": {"https://example.com/ext": {"keep": true}},
+        });
+        stamp(&mut v, &binding());
+        assert_eq!(
+            v["metadata"]["https://example.com/ext"],
+            json!({"keep": true})
+        );
+        assert_eq!(stamped(&v)["sessionId"], json!("s-1"));
+    }
+
+    #[test]
+    fn null_metadata_is_replaced_with_an_object() {
+        let mut v = json!({"messageId": "m-1", "metadata": Value::Null});
+        stamp(&mut v, &binding());
+        assert_eq!(stamped(&v)["sessionId"], json!("s-1"));
+    }
+
+    #[test]
+    fn agent_cards_and_scalars_are_untouched() {
+        // `AgentSkill` has an `id` but no `status`, so it must not match.
+        let mut v = json!({
+            "name": "card",
+            "skills": [{"id": "s", "name": "n", "description": "d", "tags": []}],
+            "count": 3,
+        });
+        let before = v.clone();
+        stamp(&mut v, &binding());
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn a_null_body_is_not_a_panic() {
+        let mut v = Value::Null;
+        stamp(&mut v, &binding());
+        assert_eq!(v, Value::Null);
+    }
+}

--- a/a2a-stdio/src/server.rs
+++ b/a2a-stdio/src/server.rs
@@ -1,0 +1,1139 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server side of the binding: the process that was spawned (2, 3.6).
+//!
+//! 3.6 wants many in-flight requests, but a frame is an indivisible header
+//! block plus body, so concurrent writers would interleave into garbage. Hence
+//! three roles: a reader that never blocks on work, N request tasks, and exactly
+//! one writer draining a bounded channel.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use a2a::error_code;
+use a2a::jsonrpc::{JsonRpcError, JsonRpcId, methods};
+use a2a_server::{RequestHandler, ServiceParams, dispatch};
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::task::JoinHandle;
+use tokio_util::codec::{FramedRead, FramedWrite};
+use tokio_util::sync::CancellationToken;
+
+use crate::codec::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_HEADER_SIZE, StdioCodec, StdioCodecError};
+use crate::frame::{Frame, FrameHeaders};
+use crate::json::{self, ClientMessage, ServerInbound, ServerMessage};
+use crate::metadata::{self, SessionBinding};
+use crate::session::{self, AckOutcome, ExitCode, FEATURE_STREAMING};
+use crate::wire::{ControlFrame, Variant, WireError};
+type Cancels = Arc<Mutex<HashMap<JsonRpcId, CancellationToken>>>;
+
+/// 7.2: framing and session failures after the handshake are reported from the
+/// JSON-RPC implementation-defined server-error range.
+const BINDING_ERROR: i32 = -32000;
+
+/// Must stay well inside the ~5 s the parent waits before `SIGTERM` (2.4).
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+pub struct ServerConfig {
+    pub max_frame_size: usize, // 3.7 recommends 1 MiB
+    pub max_header_size: usize,
+    pub outbound_capacity: usize, // mpsc depth, e.g. 64
+    pub features: Vec<String>,    // FEATURE_STREAMING, ...
+    /// 9.6 `launchDigest`, if the host computed one. There is no standard
+    /// environment variable for it, so it has to be supplied out of band.
+    pub launch_digest: Option<String>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+            max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+            max_header_size: DEFAULT_MAX_HEADER_SIZE,
+            outbound_capacity: 64,
+            features: vec![FEATURE_STREAMING.to_string()],
+            launch_digest: None,
+        }
+    }
+}
+
+/// The 2.1 startup context handed to a spawned agent.
+pub struct Startup {
+    /// From `A2A_SESSION_ID`. The handshake echoes it and the client rejects a
+    /// mismatch (2.2 step 2).
+    pub session_id: String,
+    /// 4.1: applied to every request unless that request overrides them.
+    pub session_params: ServiceParams,
+}
+
+impl Startup {
+    /// 2.1 makes `A2A_SESSION_ID` REQUIRED and `A2A_SP_*` optional.
+    pub fn from_env() -> Result<Self, ExitCode> {
+        Ok(Startup {
+            session_id: session::session_id_from_env(|k| std::env::var(k).ok())?,
+            session_params: session::service_params_from_env(std::env::vars()),
+        })
+    }
+}
+
+/// Run the agent on `STDIN`/`STDOUT` until EOF or the session ends.
+///
+/// Returns the 2.4 exit code. Pass it to `std::process::exit` only after this
+/// future resolves, or queued frames are dropped unflushed.
+pub async fn serve<H>(handler: H, config: ServerConfig) -> ExitCode
+where
+    H: RequestHandler + Send + Sync + 'static,
+{
+    let startup = match Startup::from_env() {
+        Ok(startup) => startup,
+        Err(code) => {
+            eprintln!("a2a-stdio: {} is missing or empty", session::ENV_SESSION_ID);
+            return code;
+        }
+    };
+    serve_on(
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+        startup,
+        handler,
+        config,
+    )
+    .await
+}
+
+/// Run the agent over pipes the caller supplies.
+///
+/// 2 permits serving handles obtained by other means than a spawn, so the
+/// standard streams are a default rather than a requirement.
+pub async fn serve_on<R, W, H>(
+    input: R,
+    output: W,
+    startup: Startup,
+    handler: H,
+    config: ServerConfig,
+) -> ExitCode
+where
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send + 'static,
+    H: RequestHandler + Send + Sync + 'static,
+{
+    let Startup {
+        session_id,
+        session_params,
+    } = startup;
+
+    let mut reader = FramedRead::new(
+        input,
+        StdioCodec::new(config.max_frame_size, config.max_header_size),
+    );
+    let mut writer = FramedWrite::new(
+        output,
+        StdioCodec::new(config.max_frame_size, config.max_header_size),
+    );
+
+    // ---- handshake (2.2) -------------------------------------------------
+    // Server speaks first, straight onto the sink: no concurrency exists yet.
+    let offered = session::build_handshake(
+        session_id,
+        vec![Variant::Json],
+        config.features,
+        Some(std::process::id()),
+    );
+    let hello = match encode_control(&ControlFrame::Handshake(offered.clone())) {
+        Ok(frame) => frame,
+        Err(e) => {
+            eprintln!("a2a-stdio: cannot encode handshake: {e}");
+            return ExitCode::GenericError;
+        }
+    };
+    if let Err(e) = writer.send(hello).await {
+        eprintln!("a2a-stdio: cannot write handshake: {e}");
+        return ExitCode::GenericError;
+    }
+
+    // 2.2 step 3: exactly one frame, and it must be a `handshakeAck`.
+    let ack = match reader.next().await {
+        Some(Ok(frame)) => match json::parse_from_client(&frame.body) {
+            Ok(ServerInbound::Control(ControlFrame::HandshakeAck(ack))) => ack,
+            Ok(_) => {
+                eprintln!("a2a-stdio: expected handshakeAck before any other frame");
+                return ExitCode::ProtocolError;
+            }
+            Err(e) => {
+                eprintln!("a2a-stdio: malformed handshakeAck: {e}");
+                return ExitCode::ProtocolError;
+            }
+        },
+        Some(Err(e)) => {
+            eprintln!("a2a-stdio: framing error during handshake: {e}");
+            return ExitCode::ProtocolError;
+        }
+        // Parent left before acking: nothing to serve, nothing wrong.
+        None => return ExitCode::Ok,
+    };
+
+    let variant = match session::accept_ack(&offered, &ack) {
+        Ok(AckOutcome::Accepted(v)) => v,
+        // 2.2 step 4: a refusal is a clean shutdown.
+        Ok(AckOutcome::Declined) => return ExitCode::Ok,
+        Err(e) => {
+            eprintln!("a2a-stdio: {e}");
+            return e.exit_code();
+        }
+    };
+    debug_assert_eq!(
+        variant,
+        Variant::Json,
+        "only stdio-json is advertised, so nothing else can be selected"
+    );
+
+    // ---- serving ----------------------------------------------------------
+    let binding = Arc::new(
+        SessionBinding {
+            session_id: offered.session_id,
+            pid: offered.pid,
+            variant,
+            launch_digest: config.launch_digest,
+        }
+        .to_value(),
+    );
+
+    let (tx, rx) = mpsc::channel::<Frame>(config.outbound_capacity);
+    let writer_task = tokio::spawn(write_loop(writer, rx));
+    let cancels = Cancels::default();
+
+    let exit = read_loop(
+        reader,
+        tx.clone(),
+        Arc::new(handler),
+        session_params,
+        binding,
+        cancels.clone(),
+    )
+    .await;
+
+    drain_and_flush(&cancels, tx, writer_task).await;
+    exit
+}
+
+/// The 2.4 shutdown sequence: abort in-flight work, then flush what is queued.
+///
+/// `write_loop` ends only once every sender drops, and each in-flight task holds
+/// a clone, so an open stream would keep it alive forever. Cancelling is the
+/// "abort" half of 2.4; the timeout covers unary handlers, which hold a sender
+/// but observe no token. Returns whether the writer finished in time.
+async fn drain_and_flush(cancels: &Cancels, tx: Sender<Frame>, writer: JoinHandle<()>) -> bool {
+    for (_, token) in lock(cancels).drain() {
+        token.cancel();
+    }
+    drop(tx);
+    if tokio::time::timeout(SHUTDOWN_GRACE, writer).await.is_err() {
+        eprintln!("a2a-stdio: in-flight work outlived the {SHUTDOWN_GRACE:?} drain window");
+        return false;
+    }
+    true
+}
+
+/// The only task permitted to touch `STDOUT`.
+async fn write_loop<W>(mut sink: FramedWrite<W, StdioCodec>, mut rx: Receiver<Frame>)
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(frame) = rx.recv().await {
+        if let Err(e) = sink.send(frame).await {
+            // Either a closed pipe or an encoder refusal (3.7 oversize). Both
+            // are unreportable in-band, so 1's diagnostic channel separates them.
+            eprintln!("a2a-stdio: dropping outbound frame: {e}");
+            break;
+        }
+    }
+    let _ = sink.flush().await;
+}
+
+async fn read_loop<R, H>(
+    mut reader: FramedRead<R, StdioCodec>,
+    tx: Sender<Frame>,
+    handler: Arc<H>,
+    session_params: ServiceParams,
+    binding: Arc<Value>,
+    cancels: Cancels,
+) -> ExitCode
+where
+    R: AsyncRead + Unpin,
+    H: RequestHandler + Send + Sync + 'static,
+{
+    while let Some(item) = reader.next().await {
+        let frame = match item {
+            Ok(frame) => frame,
+            // 3.7: answer an oversize frame with -32000, then exit 2.
+            Err(StdioCodecError::FrameTooLarge { len, max }) => {
+                eprintln!("a2a-stdio: frame of {len} bytes exceeds {max}");
+                send_error(&tx, JsonRpcId::Null, BINDING_ERROR, "Message too large").await;
+                return ExitCode::ProtocolError;
+            }
+            Err(e) => {
+                eprintln!("a2a-stdio: framing error: {e}");
+                return ExitCode::ProtocolError;
+            }
+        };
+
+        match json::parse_from_client(&frame.body) {
+            // 7.2: fatal, because the id is unknowable.
+            Err(WireError::Json(e)) => {
+                eprintln!("a2a-stdio: {e}");
+                send_error(&tx, JsonRpcId::Null, error_code::PARSE_ERROR, "Parse error").await;
+                return ExitCode::ProtocolError;
+            }
+            // Not fatal. The shape was rejected but 3.4 still wants the real id
+            // when it is readable, so callers can match the answer to the frame.
+            Err(e) => {
+                send_error(
+                    &tx,
+                    json::peek_id(&frame.body),
+                    error_code::INVALID_REQUEST,
+                    &e.to_string(),
+                )
+                .await;
+            }
+
+            // 2.3: a heartbeat carries nothing beyond liveness.
+            Ok(ServerInbound::Control(ControlFrame::Heartbeat(_))) => {}
+
+            // 2.2: the handshake happens once, before this loop is entered.
+            Ok(ServerInbound::Control(_)) => {
+                eprintln!("a2a-stdio: unexpected handshake frame mid-session");
+                return ExitCode::ProtocolError;
+            }
+
+            // 8.5 step 3 forbids cancelling the underlying task, so this stops
+            // the stream without ever reaching the handler.
+            Ok(ServerInbound::Message(ClientMessage::CancelStream { id })) => {
+                let token = lock(&cancels).remove(&id);
+                if let Some(token) = token {
+                    token.cancel();
+                }
+            }
+
+            Ok(ServerInbound::Message(ClientMessage::Request(req))) => {
+                // 6.9: binding-local method, absent from the A2A inventory.
+                if req.method == json::SYSTEM_SHUTDOWN {
+                    send(
+                        &tx,
+                        ServerMessage::Result {
+                            id: req.id,
+                            result: serde_json::json!({}),
+                        },
+                    )
+                    .await;
+                    return ExitCode::Ok;
+                }
+
+                let params = merge_service_params(&session_params, req.service_params.as_ref());
+                let raw_params = req.params.unwrap_or(Value::Null);
+                if methods::is_streaming(&req.method) {
+                    // 3.6: ids are unique. Reusing an open one would overwrite
+                    // its token and leave the first stream uncancellable.
+                    if lock(&cancels).contains_key(&req.id) {
+                        send_error(
+                            &tx,
+                            req.id,
+                            error_code::INVALID_REQUEST,
+                            "Duplicate request id: a stream with this id is still open",
+                        )
+                        .await;
+                        continue;
+                    }
+                    spawn_stream(
+                        handler.clone(),
+                        tx.clone(),
+                        cancels.clone(),
+                        req.id,
+                        req.method,
+                        params,
+                        raw_params,
+                        binding.clone(),
+                    );
+                } else {
+                    spawn_unary(
+                        handler.clone(),
+                        tx.clone(),
+                        req.id,
+                        req.method,
+                        params,
+                        raw_params,
+                        binding.clone(),
+                    );
+                }
+            }
+        }
+    }
+
+    // The stream ended: `STDIN` reached EOF (2.4).
+    ExitCode::Ok
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_unary<H>(
+    handler: Arc<H>,
+    tx: Sender<Frame>,
+    id: JsonRpcId,
+    method: String,
+    params: ServiceParams,
+    raw_params: Value,
+    binding: Arc<Value>,
+) where
+    H: RequestHandler + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        let msg = match dispatch::dispatch_unary(&*handler, &params, &method, raw_params).await {
+            Ok(mut result) => {
+                metadata::stamp(&mut result, &binding);
+                ServerMessage::Result { id, result }
+            }
+            Err(e) => ServerMessage::Error {
+                id,
+                error: e.into(),
+            },
+        };
+        send(&tx, msg).await;
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_stream<H>(
+    handler: Arc<H>,
+    tx: Sender<Frame>,
+    cancels: Cancels,
+    id: JsonRpcId,
+    method: String,
+    params: ServiceParams,
+    raw_params: Value,
+    binding: Arc<Value>,
+) where
+    H: RequestHandler + Send + Sync + 'static,
+{
+    let token = CancellationToken::new();
+    lock(&cancels).insert(id.clone(), token.clone());
+
+    tokio::spawn(async move {
+        match dispatch::dispatch_streaming(&*handler, &params, &method, raw_params).await {
+            // 7.3 and 8.3: an error terminates the stream and no `streamEnd` follows.
+            Err(e) => {
+                send(
+                    &tx,
+                    ServerMessage::Error {
+                        id: id.clone(),
+                        error: e.into(),
+                    },
+                )
+                .await;
+            }
+            Ok(mut stream) => loop {
+                tokio::select! {
+                    // 8.5 step 2 still wants a proper termination, hence a token
+                    // rather than aborting the task.
+                    _ = token.cancelled() => {
+                        send(&tx, ServerMessage::StreamEnd { id: id.clone() }).await;
+                        break;
+                    }
+                    item = stream.next() => match item {
+                        Some(Ok(mut result)) => {
+                            metadata::stamp(&mut result, &binding);
+                            send(&tx, ServerMessage::Result { id: id.clone(), result }).await;
+                        }
+                        Some(Err(e)) => {
+                            send(&tx, ServerMessage::Error { id: id.clone(), error: e.into() }).await;
+                            break;
+                        }
+                        None => {
+                            send(&tx, ServerMessage::StreamEnd { id: id.clone() }).await;
+                            break;
+                        }
+                    }
+                }
+            },
+        }
+        lock(&cancels).remove(&id);
+    });
+}
+
+/// 4.1: session-scoped parameters apply unless overridden per-request.
+fn merge_service_params(
+    session: &ServiceParams,
+    per_request: Option<&HashMap<String, String>>,
+) -> ServiceParams {
+    let mut merged = session.clone();
+    if let Some(wire) = per_request {
+        merged.extend(json::wire_to_service_params(wire));
+    }
+    merged
+}
+
+async fn send(tx: &Sender<Frame>, msg: ServerMessage) {
+    match encode_message(&msg) {
+        // A closed channel means the writer is gone; the reader will see EOF.
+        Ok(frame) => {
+            let _ = tx.send(frame).await;
+        }
+        Err(e) => eprintln!("a2a-stdio: cannot encode outbound frame: {e}"),
+    }
+}
+
+async fn send_error(tx: &Sender<Frame>, id: JsonRpcId, code: i32, message: &str) {
+    let error = JsonRpcError {
+        code,
+        message: message.to_string(),
+        data: None,
+    };
+    send(tx, ServerMessage::Error { id, error }).await;
+}
+
+/// No invariant here survives a panic badly, so poisoning is recovered from.
+fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// No optional headers: 3.1 defaults `Content-Type` for `stdio-json`.
+fn json_frame(body: Vec<u8>) -> Frame {
+    Frame {
+        headers: FrameHeaders::default(),
+        body: Bytes::from(body),
+    }
+}
+
+fn encode_control(frame: &ControlFrame) -> Result<Frame, serde_json::Error> {
+    Ok(json_frame(serde_json::to_vec(frame)?))
+}
+
+fn encode_message(msg: &ServerMessage) -> Result<Frame, serde_json::Error> {
+    Ok(json_frame(msg.to_vec()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a::{A2AError, error_code};
+    use futures::stream::{self, BoxStream};
+    use serde_json::json;
+
+    // Only two methods are live: `DeleteTaskPushNotificationConfig` is the one
+    // unary call returning `null`, and `SubscribeToTask` needs no constructed
+    // items. The rest would drag fixtures into tests about framing.
+
+    #[derive(Default, Clone, Copy, PartialEq)]
+    enum StreamKind {
+        #[default]
+        Empty,
+        /// Only cancellation can close this one.
+        Pending,
+        /// Fails before the first item (7.3).
+        Rejected,
+        /// One `Task` then end, for the 9.6 stamping check.
+        OneTask,
+    }
+
+    fn sample_task() -> a2a::Task {
+        a2a::Task {
+            id: "t-1".into(),
+            context_id: "c-1".into(),
+            status: a2a::TaskStatus {
+                state: a2a::TaskState::Completed,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        }
+    }
+
+    #[derive(Default)]
+    struct MockHandler {
+        stream: StreamKind,
+        seen: Mutex<Vec<ServiceParams>>,
+    }
+
+    impl MockHandler {
+        fn with_stream(stream: StreamKind) -> Self {
+            MockHandler {
+                stream,
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn unused(method: &str) -> A2AError {
+            A2AError::internal(format!("{method} is not exercised by these tests"))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RequestHandler for MockHandler {
+        async fn delete_push_config(
+            &self,
+            params: &ServiceParams,
+            _req: a2a::DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            lock(&self.seen).push(params.clone());
+            Ok(())
+        }
+
+        async fn subscribe_to_task(
+            &self,
+            params: &ServiceParams,
+            _req: a2a::SubscribeToTaskRequest,
+        ) -> Result<BoxStream<'static, Result<a2a::StreamResponse, A2AError>>, A2AError> {
+            lock(&self.seen).push(params.clone());
+            match self.stream {
+                StreamKind::Empty => Ok(Box::pin(stream::empty())),
+                StreamKind::Pending => Ok(Box::pin(stream::pending())),
+                StreamKind::Rejected => Err(A2AError::internal("stream refused")),
+                StreamKind::OneTask => Ok(Box::pin(stream::once(async {
+                    Ok(a2a::StreamResponse::Task(sample_task()))
+                }))),
+            }
+        }
+
+        async fn send_message(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::SendMessageRequest,
+        ) -> Result<a2a::SendMessageResponse, A2AError> {
+            Err(Self::unused("send_message"))
+        }
+
+        async fn send_streaming_message(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::SendMessageRequest,
+        ) -> Result<BoxStream<'static, Result<a2a::StreamResponse, A2AError>>, A2AError> {
+            Err(Self::unused("send_streaming_message"))
+        }
+
+        async fn get_task(
+            &self,
+            params: &ServiceParams,
+            _req: a2a::GetTaskRequest,
+        ) -> Result<a2a::Task, A2AError> {
+            lock(&self.seen).push(params.clone());
+            Ok(sample_task())
+        }
+
+        async fn list_tasks(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::ListTasksRequest,
+        ) -> Result<a2a::ListTasksResponse, A2AError> {
+            Err(Self::unused("list_tasks"))
+        }
+
+        async fn cancel_task(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::CancelTaskRequest,
+        ) -> Result<a2a::Task, A2AError> {
+            Err(Self::unused("cancel_task"))
+        }
+
+        async fn create_push_config(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::TaskPushNotificationConfig,
+        ) -> Result<a2a::TaskPushNotificationConfig, A2AError> {
+            Err(Self::unused("create_push_config"))
+        }
+
+        async fn get_push_config(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::GetTaskPushNotificationConfigRequest,
+        ) -> Result<a2a::TaskPushNotificationConfig, A2AError> {
+            Err(Self::unused("get_push_config"))
+        }
+
+        async fn list_push_configs(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::ListTaskPushNotificationConfigsRequest,
+        ) -> Result<a2a::ListTaskPushNotificationConfigsResponse, A2AError> {
+            Err(Self::unused("list_push_configs"))
+        }
+
+        async fn get_extended_agent_card(
+            &self,
+            _params: &ServiceParams,
+            _req: a2a::GetExtendedAgentCardRequest,
+        ) -> Result<a2a::AgentCard, A2AError> {
+            Err(Self::unused("get_extended_agent_card"))
+        }
+    }
+
+    fn test_binding() -> Value {
+        SessionBinding {
+            session_id: "s-1".into(),
+            pid: Some(42137),
+            variant: Variant::Json,
+            launch_digest: None,
+        }
+        .to_value()
+    }
+
+    /// Framed by hand, so an encoder bug cannot make these tests agree with
+    /// themselves.
+    fn framed(body: &[u8]) -> Vec<u8> {
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn frames(bodies: &[Value]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for body in bodies {
+            out.extend_from_slice(&framed(&serde_json::to_vec(body).unwrap()));
+        }
+        out
+    }
+
+    /// Drive `read_loop` to EOF and collect what reached the writer channel.
+    /// The drain needs its timeout because an unending stream holds a sender.
+    async fn run(
+        handler: MockHandler,
+        session_params: ServiceParams,
+        input: Vec<u8>,
+    ) -> (ExitCode, Arc<MockHandler>, Vec<ServerMessage>) {
+        let handler = Arc::new(handler);
+        let (tx, mut rx) = mpsc::channel::<Frame>(64);
+        let reader = FramedRead::new(
+            input.as_slice(),
+            StdioCodec::new(DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_HEADER_SIZE),
+        );
+
+        let exit = read_loop(
+            reader,
+            tx,
+            handler.clone(),
+            session_params,
+            Arc::new(test_binding()),
+            Cancels::default(),
+        )
+        .await;
+
+        let mut out = Vec::new();
+        while let Ok(Some(frame)) =
+            tokio::time::timeout(Duration::from_millis(250), rx.recv()).await
+        {
+            match json::parse_from_server(&frame.body).expect("server emitted an unreadable frame")
+            {
+                crate::json::ClientInbound::Message(m) => out.push(m),
+                other => panic!("unexpected control frame on the response path: {other:?}"),
+            }
+        }
+        (exit, handler, out)
+    }
+
+    async fn run_plain(input: Vec<u8>) -> (ExitCode, Vec<ServerMessage>) {
+        let (exit, _, out) = run(MockHandler::default(), ServiceParams::default(), input).await;
+        (exit, out)
+    }
+
+    fn request(id: Value, method: &str) -> Value {
+        json!({"jsonrpc": "2.0", "id": id, "method": method, "params": {}})
+    }
+
+    fn error_of(msg: &ServerMessage) -> &JsonRpcError {
+        match msg {
+            ServerMessage::Error { error, .. } => error,
+            other => panic!("expected an error, got {other:?}"),
+        }
+    }
+
+    // --- unary dispatch ---
+
+    #[tokio::test]
+    async fn unary_request_is_answered_once_and_eof_is_clean() {
+        let (exit, out) = run_plain(frames(&[request(
+            json!("d-1"),
+            methods::DELETE_PUSH_CONFIG,
+        )]))
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok, "EOF on STDIN is 2.4 exit 0");
+        assert_eq!(out.len(), 1, "got {out:?}");
+        assert_eq!(
+            out[0],
+            ServerMessage::Result {
+                id: JsonRpcId::String("d-1".into()),
+                result: Value::Null,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_method_is_answered_without_ending_the_session() {
+        let (exit, out) = run_plain(frames(&[
+            request(json!(1), "NoSuchMethod"),
+            request(json!(2), methods::DELETE_PUSH_CONFIG),
+        ]))
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(out.len(), 2, "the second request must still be served");
+        assert_eq!(error_of(&out[0]).code, error_code::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn requests_are_not_serialized_behind_each_other() {
+        // Two ids in flight at once: the reader must not block on the first.
+        let input = frames(&[
+            request(json!("a"), methods::DELETE_PUSH_CONFIG),
+            request(json!("b"), methods::DELETE_PUSH_CONFIG),
+            request(json!("c"), methods::DELETE_PUSH_CONFIG),
+        ]);
+        let (_, _, out) = run(MockHandler::default(), ServiceParams::default(), input).await;
+
+        let mut ids: Vec<String> = out
+            .iter()
+            .map(|m| match m {
+                ServerMessage::Result {
+                    id: JsonRpcId::String(s),
+                    ..
+                } => s.clone(),
+                other => panic!("expected string-id results, got {other:?}"),
+            })
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+
+    // --- malformed input (7.2) ---
+
+    #[tokio::test]
+    async fn malformed_json_is_fatal_and_answered_with_a_null_id() {
+        let (exit, out) = run_plain(framed(b"{not json")).await;
+
+        assert_eq!(exit, ExitCode::ProtocolError, "7.2 makes this exit 2");
+        assert_eq!(out.len(), 1);
+        assert_eq!(error_of(&out[0]).code, error_code::PARSE_ERROR);
+        match &out[0] {
+            ServerMessage::Error { id, .. } => assert_eq!(*id, JsonRpcId::Null),
+            other => panic!("expected error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unclassifiable_frame_is_answered_against_its_own_id() {
+        // 3.4 keeps null for unreadable ids; this one is readable, the shape is not.
+        let (exit, out) = run_plain(frames(&[
+            json!({"jsonrpc": "2.0", "id": "req-7"}),
+            request(json!("after"), methods::DELETE_PUSH_CONFIG),
+        ]))
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok, "a bad shape is not fatal");
+        assert_eq!(out.len(), 2);
+        assert_eq!(error_of(&out[0]).code, error_code::INVALID_REQUEST);
+        match &out[0] {
+            ServerMessage::Error { id, .. } => {
+                assert_eq!(*id, JsonRpcId::String("req-7".into()));
+            }
+            other => panic!("expected error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn oversize_frame_is_refused_and_ends_the_session() {
+        let body =
+            serde_json::to_vec(&json!({"jsonrpc": "2.0", "id": 1, "pad": "x".repeat(64)})).unwrap();
+        let (tx, mut rx) = mpsc::channel::<Frame>(8);
+        let input = framed(&body);
+        // A limit below the body forces the 3.7 path without a megabyte of input.
+        let reader = FramedRead::new(
+            input.as_slice(),
+            StdioCodec::new(16, DEFAULT_MAX_HEADER_SIZE),
+        );
+
+        let exit = read_loop(
+            reader,
+            tx,
+            Arc::new(MockHandler::default()),
+            ServiceParams::default(),
+            Arc::new(test_binding()),
+            Cancels::default(),
+        )
+        .await;
+
+        assert_eq!(exit, ExitCode::ProtocolError);
+        let frame = rx.recv().await.expect("expected a -32000 answer");
+        let msg = json::parse_from_server(&frame.body).unwrap();
+        match msg {
+            crate::json::ClientInbound::Message(m) => {
+                assert_eq!(error_of(&m).code, BINDING_ERROR);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    // --- control frames (2.2, 2.3) ---
+
+    #[tokio::test]
+    async fn heartbeat_is_accepted_and_answered_with_nothing() {
+        let (exit, out) = run_plain(frames(&[
+            json!({"type": "heartbeat", "sessionId": "s-1", "ts": 1_700_000_000_000u64}),
+        ]))
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert!(out.is_empty(), "a heartbeat carries no reply: {out:?}");
+    }
+
+    #[tokio::test]
+    async fn a_second_handshake_is_a_protocol_violation() {
+        let (exit, _) = run_plain(frames(&[
+            json!({"type": "handshakeAck", "sessionId": "s-1", "selectVariant": "stdio-json", "accept": true}),
+        ]))
+        .await;
+
+        assert_eq!(exit, ExitCode::ProtocolError, "2.2 happens exactly once");
+    }
+
+    // --- streaming (8) ---
+
+    #[tokio::test]
+    async fn empty_stream_is_closed_with_stream_end() {
+        let input = frames(&[request(json!("s-1"), methods::SUBSCRIBE_TO_TASK)]);
+        let (exit, _, out) = run(
+            MockHandler::with_stream(StreamKind::Empty),
+            ServiceParams::default(),
+            input,
+        )
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(
+            out,
+            vec![ServerMessage::StreamEnd {
+                id: JsonRpcId::String("s-1".into())
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_stream_ends_with_an_error_and_no_stream_end() {
+        let input = frames(&[request(json!("s-1"), methods::SUBSCRIBE_TO_TASK)]);
+        let (_, _, out) = run(
+            MockHandler::with_stream(StreamKind::Rejected),
+            ServiceParams::default(),
+            input,
+        )
+        .await;
+
+        assert_eq!(out.len(), 1, "7.3: the error is the termination: {out:?}");
+        assert!(matches!(out[0], ServerMessage::Error { .. }), "got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn cancel_stream_terminates_an_open_stream_with_stream_end() {
+        let input = frames(&[
+            request(json!("s-1"), methods::SUBSCRIBE_TO_TASK),
+            json!({"jsonrpc": "2.0", "id": "s-1", "cancelStream": true}),
+        ]);
+        let (exit, _, out) = run(
+            MockHandler::with_stream(StreamKind::Pending),
+            ServiceParams::default(),
+            input,
+        )
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(
+            out,
+            vec![ServerMessage::StreamEnd {
+                id: JsonRpcId::String("s-1".into())
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelling_an_unknown_id_is_ignored() {
+        let (exit, out) = run_plain(frames(&[
+            json!({"jsonrpc": "2.0", "id": "ghost", "cancelStream": true}),
+        ]))
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert!(out.is_empty(), "got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn a_reused_streaming_id_is_refused_while_the_first_is_open() {
+        let input = frames(&[
+            request(json!("dup"), methods::SUBSCRIBE_TO_TASK),
+            request(json!("dup"), methods::SUBSCRIBE_TO_TASK),
+        ]);
+        let (exit, _, out) = run(
+            MockHandler::with_stream(StreamKind::Pending),
+            ServiceParams::default(),
+            input,
+        )
+        .await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(out.len(), 1, "only the refusal is emitted: {out:?}");
+        assert_eq!(error_of(&out[0]).code, error_code::INVALID_REQUEST);
+    }
+
+    // --- session binding (9.6) ---
+
+    fn binding_of(msg: &ServerMessage) -> &Value {
+        match msg {
+            ServerMessage::Result { result, .. } => &result["metadata"][metadata::BINDING_URI],
+            other => panic!("expected a result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_unary_task_carries_the_session_binding() {
+        let (_, _, out) = run(
+            MockHandler::default(),
+            ServiceParams::default(),
+            frames(&[request(json!("g-1"), methods::GET_TASK)]),
+        )
+        .await;
+
+        assert_eq!(out.len(), 1, "got {out:?}");
+        assert_eq!(binding_of(&out[0])["sessionId"], json!("s-1"));
+        assert_eq!(binding_of(&out[0])["pid"], json!(42137));
+        assert_eq!(binding_of(&out[0])["variant"], json!("stdio-json"));
+    }
+
+    #[tokio::test]
+    async fn each_stream_item_carries_the_session_binding() {
+        let (_, _, out) = run(
+            MockHandler::with_stream(StreamKind::OneTask),
+            ServiceParams::default(),
+            frames(&[request(json!("s-1"), methods::SUBSCRIBE_TO_TASK)]),
+        )
+        .await;
+
+        assert_eq!(out.len(), 2, "one result then streamEnd: {out:?}");
+        // A stream item is a `StreamResponse`, so the task sits under the oneof
+        // field and the wrapper itself is not something 9.6 stamps.
+        let task = match &out[0] {
+            ServerMessage::Result { result, .. } => &result["task"],
+            other => panic!("expected a result, got {other:?}"),
+        };
+        assert_eq!(
+            task["metadata"][metadata::BINDING_URI]["sessionId"],
+            json!("s-1")
+        );
+        assert!(
+            matches!(out[1], ServerMessage::StreamEnd { .. }),
+            "got {out:?}"
+        );
+    }
+
+    // --- shutdown and service parameters ---
+
+    #[tokio::test]
+    async fn system_shutdown_is_answered_then_ends_the_loop() {
+        let input = frames(&[
+            json!({"jsonrpc": "2.0", "id": 9, "method": json::SYSTEM_SHUTDOWN}),
+            request(json!(10), methods::DELETE_PUSH_CONFIG),
+        ]);
+        let (exit, out) = run_plain(input).await;
+
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(
+            out,
+            vec![ServerMessage::Result {
+                id: JsonRpcId::Number(9),
+                result: json!({}),
+            }],
+            "6.9: nothing after the shutdown is served"
+        );
+    }
+
+    /// A writer over a discard sink, plus the channel feeding it.
+    fn writer_pair() -> (Sender<Frame>, JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel::<Frame>(8);
+        let sink = FramedWrite::new(
+            tokio::io::sink(),
+            StdioCodec::new(DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_HEADER_SIZE),
+        );
+        (tx, tokio::spawn(write_loop(sink, rx)))
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_an_open_stream_rather_than_waiting_on_it() {
+        let (tx, writer) = writer_pair();
+        let cancels = Cancels::default();
+
+        // A stream that never ends on its own. Its sender used to keep
+        // `write_loop` alive forever, so `serve` never returned.
+        let token = CancellationToken::new();
+        lock(&cancels).insert(JsonRpcId::String("open".into()), token.clone());
+        let task_tx = tx.clone();
+        tokio::spawn(async move {
+            token.cancelled().await;
+            drop(task_tx);
+        });
+
+        assert!(
+            drain_and_flush(&cancels, tx, writer).await,
+            "the drain must finish once the stream is cancelled"
+        );
+        assert!(lock(&cancels).is_empty(), "the registry is emptied");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_gives_up_on_work_that_cancellation_cannot_reach() {
+        let (tx, writer) = writer_pair();
+        let cancels = Cancels::default();
+
+        // A unary handler observes no token, so only the grace window bounds this.
+        let task_tx = tx.clone();
+        tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            drop(task_tx);
+        });
+
+        assert!(
+            !drain_and_flush(&cancels, tx, writer).await,
+            "the drain must give up instead of hanging"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_nothing_in_flight_returns_immediately() {
+        let (tx, writer) = writer_pair();
+        assert!(drain_and_flush(&Cancels::default(), tx, writer).await);
+    }
+
+    #[tokio::test]
+    async fn session_params_are_visible_to_the_handler_and_overridable() {
+        let mut session = ServiceParams::default();
+        session.insert("a2a-version".into(), vec!["1.0".into()]);
+        session.insert("x-tenant".into(), vec!["acme".into()]);
+
+        let input = frames(&[json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": methods::DELETE_PUSH_CONFIG,
+            "params": {},
+            "serviceParams": {"x-tenant": "override"},
+        })]);
+        let (_, handler, _) = run(MockHandler::default(), session, input).await;
+
+        let seen = lock(&handler.seen);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0]["a2a-version"], vec!["1.0".to_string()]);
+        assert_eq!(
+            seen[0]["x-tenant"],
+            vec!["override".to_string()],
+            "the request wins over the session"
+        );
+    }
+}

--- a/a2a-stdio/src/session.rs
+++ b/a2a-stdio/src/session.rs
@@ -1,0 +1,464 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process lifecycle and startup handshake (2).
+//!
+//! Roles here are process roles, not network roles: the *client* is the parent
+//! that spawns, the *server* is the child that was spawned. The handshake is
+//! server-first (2.2) — child emits `handshake`, parent replies `handshakeAck`.
+//! Both halves live together so they stay consistent, though only one runs in
+//! any given process, and both are pure so negotiation is testable without
+//! spawning anything.
+
+use std::collections::HashMap;
+
+use crate::wire::{Handshake, HandshakeAck, Variant};
+
+pub const ENV_SESSION_ID: &str = "A2A_SESSION_ID"; // REQUIRED
+pub const ENV_PROTOCOL_VERSION: &str = "A2A_PROTOCOL_VERSION";
+pub const ENV_LOG_LEVEL: &str = "A2A_LOG_LEVEL";
+pub const ENV_SERVICE_PARAM_PREFIX: &str = "A2A_SP_";
+pub const PROTOCOL_NAME: &str = "a2a-stdio";
+pub const PROTOCOL_VERSION: &str = "1.0";
+
+/// Values advertised in the handshake `features` array (2.2, 2.3).
+pub const FEATURE_STREAMING: &str = "streaming";
+
+/// Reserved. 2.3 makes heartbeats OPTIONAL and nothing here emits or polices
+/// them yet, so advertising this would promise liveness the server never keeps.
+pub const FEATURE_HEARTBEATS: &str = "heartbeats";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ExitCode {
+    Ok = 0,                  // graceful shutdown, or handshake declined
+    GenericError = 1,        // unspecified fatal error
+    ProtocolError = 2,       // malformed framing or handshake violation
+    VersionNotSupported = 3, // client asked for an A2A version we cannot serve
+    StartupDenied = 4,       // required startup context missing/invalid
+}
+impl ExitCode {
+    pub fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+pub fn service_params_from_env<I>(vars: I) -> HashMap<String, Vec<String>>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut result = HashMap::new();
+    for (name, value) in vars {
+        let Some(rest) = name.strip_prefix(ENV_SERVICE_PARAM_PREFIX) else {
+            continue;
+        };
+        let key = rest.to_ascii_lowercase().replace('_', "-");
+        let values = split_and_trim(value.split(','));
+        result.insert(key, values);
+    }
+    result
+}
+
+fn split_and_trim<'a>(iter: impl Iterator<Item = &'a str>) -> Vec<String> {
+    iter.map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+pub fn session_id_from_env(get: impl Fn(&str) -> Option<String>) -> Result<String, ExitCode> {
+    let Some(session_id) = get(ENV_SESSION_ID) else {
+        return Err(ExitCode::StartupDenied);
+    };
+    if session_id.is_empty() {
+        return Err(ExitCode::StartupDenied);
+    }
+    Ok(session_id)
+}
+
+// ---------------------------------------------------------------------------
+// Negotiation errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum NegotiationError {
+    #[error("peer reported protocol {0:?}, expected \"a2a-stdio\"")]
+    UnknownProtocol(String),
+
+    #[error("session id mismatch: expected {expected:?}, got {actual:?}")]
+    SessionIdMismatch { expected: String, actual: String },
+
+    #[error("peer selected variant {0:?} which was not offered")]
+    VariantNotOffered(Variant),
+
+    #[error("no serialization variant in common")]
+    NoCommonVariant,
+
+    #[error("protocol version {0:?} is not supported")]
+    VersionNotSupported(String),
+}
+
+impl NegotiationError {
+    /// Keeps the 7.2 / 2.4 error-to-exit-code mapping in a single place.
+    pub fn exit_code(&self) -> ExitCode {
+        match self {
+            NegotiationError::VersionNotSupported(_) => ExitCode::VersionNotSupported,
+            _ => ExitCode::ProtocolError,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server side (runs in the spawned child)
+// ---------------------------------------------------------------------------
+/// What the client's `handshakeAck` told us to do (2.2 steps 3-5).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckOutcome {
+    /// Serve every subsequent A2A frame using this variant.
+    Accepted(Variant),
+    /// The client refused the session; exit with [`ExitCode::Ok`].
+    Declined,
+}
+
+/// Build the `handshake` frame the server writes to `STDOUT` at startup (2.2 step 1).
+///
+/// `supported` is ordered by server preference, most preferred first, and must
+/// contain [`Variant::Json`] because 1 makes `stdio-json` mandatory for servers.
+/// `session_id` must be the value received in `A2A_SESSION_ID` (2.2 step 2).
+pub fn build_handshake(
+    session_id: String,
+    supported: Vec<Variant>,
+    features: Vec<String>,
+    pid: Option<u32>,
+) -> Handshake {
+    debug_assert!(
+        supported.contains(&Variant::Json),
+        "servers must support stdio-json (1)"
+    );
+    Handshake {
+        protocol: PROTOCOL_NAME.to_string(),
+        protocol_version: PROTOCOL_VERSION.to_string(),
+        session_id,
+        supported_variants: supported,
+        features,
+        pid,
+    }
+}
+
+/// Validate the client's reply against what we offered (2.2 steps 3-5).
+///
+/// `offered` is the frame previously produced by [`build_handshake`].
+pub fn accept_ack(offered: &Handshake, ack: &HandshakeAck) -> Result<AckOutcome, NegotiationError> {
+    // Identity before intent: a frame we cannot attribute to this session is not
+    // one whose `accept` flag we should act on.
+    if ack.session_id != offered.session_id {
+        return Err(NegotiationError::SessionIdMismatch {
+            expected: offered.session_id.clone(),
+            actual: ack.session_id.clone(),
+        });
+    }
+
+    // 2.2 step 4: a refusal is a clean shutdown, not a protocol violation.
+    if !ack.accept {
+        return Ok(AckOutcome::Declined);
+    }
+
+    // 2.2 step 5: selecting a variant we never advertised is fatal.
+    if !offered.supported_variants.contains(&ack.select_variant) {
+        return Err(NegotiationError::VariantNotOffered(ack.select_variant));
+    }
+
+    Ok(AckOutcome::Accepted(ack.select_variant))
+}
+
+// ---------------------------------------------------------------------------
+// Client side (runs in the spawning parent)
+// ---------------------------------------------------------------------------
+
+/// Validate the server's `handshake` and choose a variant (2.2 steps 2-3).
+///
+/// `expected_session_id` is the value the parent passed as `A2A_SESSION_ID`;
+/// `client_supported` is what this client can actually speak. Returns the ack to
+/// write to the child's `STDIN` together with the agreed variant.
+pub fn respond_to_handshake(
+    hs: &Handshake,
+    expected_session_id: &str,
+    client_supported: &[Variant],
+) -> Result<(HandshakeAck, Variant), NegotiationError> {
+    if hs.protocol != PROTOCOL_NAME {
+        return Err(NegotiationError::UnknownProtocol(hs.protocol.clone()));
+    }
+
+    // 2.2 step 2: the client MUST reject a session id that is not its own.
+    if hs.session_id != expected_session_id {
+        return Err(NegotiationError::SessionIdMismatch {
+            expected: expected_session_id.into(),
+            actual: hs.session_id.clone(),
+        });
+    }
+
+    if !version_compatible(&hs.protocol_version) {
+        return Err(NegotiationError::VersionNotSupported(
+            hs.protocol_version.clone(),
+        ));
+    }
+
+    // Walk the server's list in its own order: that ordering is the server's
+    // preference (2.2 step 1), and ours is not consulted.
+    let chosen = *hs
+        .supported_variants
+        .iter()
+        .find(|v| client_supported.contains(v))
+        .ok_or(NegotiationError::NoCommonVariant)?;
+
+    Ok((
+        HandshakeAck {
+            session_id: hs.session_id.clone(),
+            select_variant: chosen,
+            accept: true,
+        },
+        chosen,
+    ))
+}
+
+/// Refuse the session (2.2 step 4). The server exits with [`ExitCode::Ok`], so
+/// this is a polite goodbye rather than an error; `select_variant` is ignored.
+pub fn decline(session_id: &str) -> HandshakeAck {
+    HandshakeAck {
+        session_id: session_id.into(),
+        select_variant: Variant::Json,
+        accept: false,
+    }
+}
+
+/// Major versions must agree; a newer minor is assumed backward compatible.
+fn version_compatible(peer: &str) -> bool {
+    fn major(v: &str) -> Option<&str> {
+        v.split('.').next().filter(|s| !s.is_empty())
+    }
+    match (major(peer), major(PROTOCOL_VERSION)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offered(supported: Vec<Variant>) -> Handshake {
+        build_handshake("s-1".into(), supported, vec![], Some(42137))
+    }
+
+    fn ack(session_id: &str, select_variant: Variant, accept: bool) -> HandshakeAck {
+        HandshakeAck {
+            session_id: session_id.into(),
+            select_variant,
+            accept,
+        }
+    }
+
+    #[test]
+    fn handshake_carries_the_binding_identity() {
+        let hs = offered(vec![Variant::Json]);
+        assert_eq!(hs.protocol, "a2a-stdio");
+        assert_eq!(hs.protocol_version, "1.0");
+        assert_eq!(hs.session_id, "s-1");
+        assert_eq!(hs.pid, Some(42137));
+    }
+
+    #[test]
+    fn handshake_preserves_preference_order() {
+        // 2.2 step 1: the client walks this list in order, so it must not be reordered.
+        let hs = offered(vec![Variant::Proto, Variant::Json]);
+        assert_eq!(hs.supported_variants, vec![Variant::Proto, Variant::Json]);
+    }
+
+    #[test]
+    fn accepted_ack_selects_the_variant() {
+        let hs = offered(vec![Variant::Json, Variant::Proto]);
+        let out = accept_ack(&hs, &ack("s-1", Variant::Proto, true)).unwrap();
+        assert_eq!(out, AckOutcome::Accepted(Variant::Proto));
+    }
+
+    #[test]
+    fn declined_ack_is_a_clean_shutdown_not_an_error() {
+        let hs = offered(vec![Variant::Json]);
+        let out = accept_ack(&hs, &ack("s-1", Variant::Json, false)).unwrap();
+        assert_eq!(out, AckOutcome::Declined);
+    }
+
+    #[test]
+    fn selecting_an_unoffered_variant_is_a_protocol_error() {
+        let hs = offered(vec![Variant::Json]);
+        let err = accept_ack(&hs, &ack("s-1", Variant::Proto, true)).unwrap_err();
+        assert!(
+            matches!(err, NegotiationError::VariantNotOffered(Variant::Proto)),
+            "got {err:?}"
+        );
+        assert_eq!(err.exit_code(), ExitCode::ProtocolError);
+    }
+
+    #[test]
+    fn mismatched_session_id_is_rejected_even_when_declining() {
+        let hs = offered(vec![Variant::Json]);
+        let err = accept_ack(&hs, &ack("other", Variant::Json, false)).unwrap_err();
+        assert!(
+            matches!(err, NegotiationError::SessionIdMismatch { .. }),
+            "got {err:?}"
+        );
+        assert_eq!(err.exit_code(), ExitCode::ProtocolError);
+    }
+
+    #[test]
+    fn version_failures_use_their_own_exit_code() {
+        let err = NegotiationError::VersionNotSupported("9.9".into());
+        assert_eq!(err.exit_code(), ExitCode::VersionNotSupported);
+        assert_eq!(err.exit_code().as_i32(), 3);
+    }
+
+    #[test]
+    fn client_honours_the_servers_preference_order() {
+        // Server prefers json; our own list prefers proto. The server wins.
+        let hs = offered(vec![Variant::Json, Variant::Proto]);
+        let (ack, chosen) =
+            respond_to_handshake(&hs, "s-1", &[Variant::Proto, Variant::Json]).unwrap();
+        assert_eq!(chosen, Variant::Json);
+        assert_eq!(ack.select_variant, Variant::Json);
+        assert!(ack.accept);
+        assert_eq!(ack.session_id, "s-1");
+    }
+
+    #[test]
+    fn client_skips_variants_it_cannot_speak() {
+        let hs = offered(vec![Variant::Proto, Variant::Json]);
+        let (_, chosen) = respond_to_handshake(&hs, "s-1", &[Variant::Json]).unwrap();
+        assert_eq!(chosen, Variant::Json);
+    }
+
+    #[test]
+    fn no_overlap_is_reported_as_no_common_variant() {
+        let hs = offered(vec![Variant::Json]);
+        let err = respond_to_handshake(&hs, "s-1", &[Variant::Proto]).unwrap_err();
+        assert!(
+            matches!(err, NegotiationError::NoCommonVariant),
+            "got {err:?}"
+        );
+        assert_eq!(err.exit_code(), ExitCode::ProtocolError);
+    }
+
+    #[test]
+    fn empty_variant_list_does_not_panic() {
+        // Built by hand: a conformant server never sends this, but a buggy or
+        // hostile one can, and it must not take the client process down.
+        let hs = Handshake {
+            protocol: PROTOCOL_NAME.into(),
+            protocol_version: PROTOCOL_VERSION.into(),
+            session_id: "s-1".into(),
+            supported_variants: vec![],
+            features: vec![],
+            pid: None,
+        };
+        assert!(matches!(
+            respond_to_handshake(&hs, "s-1", &[Variant::Json]).unwrap_err(),
+            NegotiationError::NoCommonVariant
+        ));
+    }
+
+    #[test]
+    fn client_rejects_a_foreign_session_id() {
+        let hs = offered(vec![Variant::Json]);
+        match respond_to_handshake(&hs, "s-2", &[Variant::Json]).unwrap_err() {
+            NegotiationError::SessionIdMismatch { expected, actual } => {
+                assert_eq!(expected, "s-2");
+                assert_eq!(actual, "s-1");
+            }
+            other => panic!("expected SessionIdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn client_rejects_a_foreign_protocol() {
+        let mut hs = offered(vec![Variant::Json]);
+        hs.protocol = "not-a2a".into();
+        let err = respond_to_handshake(&hs, "s-1", &[Variant::Json]).unwrap_err();
+        assert!(
+            matches!(err, NegotiationError::UnknownProtocol(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn incompatible_major_version_exits_with_code_three() {
+        let mut hs = offered(vec![Variant::Json]);
+        hs.protocol_version = "2.0".into();
+        let err = respond_to_handshake(&hs, "s-1", &[Variant::Json]).unwrap_err();
+        assert!(
+            matches!(err, NegotiationError::VersionNotSupported(ref v) if v == "2.0"),
+            "got {err:?}"
+        );
+        assert_eq!(err.exit_code().as_i32(), 3);
+    }
+
+    #[test]
+    fn newer_minor_version_is_accepted() {
+        let mut hs = offered(vec![Variant::Json]);
+        hs.protocol_version = "1.7".into();
+        assert!(respond_to_handshake(&hs, "s-1", &[Variant::Json]).is_ok());
+    }
+
+    #[test]
+    fn decline_refuses_without_selecting() {
+        let ack = decline("s-1");
+        assert!(!ack.accept);
+        assert_eq!(ack.session_id, "s-1");
+    }
+
+    #[test]
+    fn the_two_halves_agree_on_a_full_exchange() {
+        // Server offers, client responds, server validates the response.
+        let hs = offered(vec![Variant::Json, Variant::Proto]);
+        let (ack, client_choice) =
+            respond_to_handshake(&hs, "s-1", &[Variant::Json, Variant::Proto]).unwrap();
+        assert_eq!(
+            accept_ack(&hs, &ack).unwrap(),
+            AckOutcome::Accepted(client_choice)
+        );
+    }
+
+    #[test]
+    fn a_declining_client_is_seen_as_a_clean_shutdown() {
+        let hs = offered(vec![Variant::Json]);
+        assert_eq!(
+            accept_ack(&hs, &decline("s-1")).unwrap(),
+            AckOutcome::Declined
+        );
+    }
+
+    #[test]
+    fn missing_or_empty_session_id_denies_startup() {
+        assert_eq!(
+            session_id_from_env(|_| None).unwrap_err(),
+            ExitCode::StartupDenied
+        );
+        assert_eq!(
+            session_id_from_env(|_| Some(String::new())).unwrap_err(),
+            ExitCode::StartupDenied
+        );
+        assert_eq!(session_id_from_env(|_| Some("s-1".into())).unwrap(), "s-1");
+    }
+
+    #[test]
+    fn env_service_params_are_normalized() {
+        // 4.1: strip the prefix, lowercase, underscores become hyphens.
+        let vars = vec![
+            ("A2A_SP_A2A_VERSION".to_string(), "1.0".to_string()),
+            ("A2A_SP_A2A_EXTENSIONS".to_string(), "a, b ,c".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        let sp = service_params_from_env(vars);
+        assert_eq!(sp["a2a-version"], vec!["1.0"]);
+        assert_eq!(sp["a2a-extensions"], vec!["a", "b", "c"]);
+        assert!(!sp.contains_key("path"), "unprefixed vars must be ignored");
+    }
+}

--- a/a2a-stdio/src/wire.rs
+++ b/a2a-stdio/src/wire.rs
@@ -1,0 +1,86 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Control frames and errors shared by both serialization variants.
+//!
+//! Per 2.2, `handshake`, `handshakeAck` and `heartbeat` are always UTF-8 JSON
+//! regardless of the negotiated variant, because the variant is not yet chosen
+//! when they are exchanged.
+
+use serde::{Deserialize, Serialize};
+
+/// Serialization variant negotiated during the handshake (2.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Variant {
+    #[serde(rename = "stdio-json")]
+    Json,
+    #[serde(rename = "stdio-proto")]
+    Proto,
+}
+
+impl Variant {
+    /// The token used on the wire; must match the serde renames above.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Variant::Json => "stdio-json",
+            Variant::Proto => "stdio-proto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Handshake {
+    pub protocol: String,
+    pub protocol_version: String,
+    pub session_id: String,
+    /// Ordered by server preference, most preferred first (2.2).
+    pub supported_variants: Vec<Variant>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandshakeAck {
+    pub session_id: String,
+    pub select_variant: Variant,
+    pub accept: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Heartbeat {
+    pub session_id: String,
+    /// Unix epoch milliseconds.
+    pub ts: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ControlFrame {
+    #[serde(rename = "handshake")]
+    Handshake(Handshake),
+    #[serde(rename = "handshakeAck")]
+    HandshakeAck(HandshakeAck),
+    #[serde(rename = "heartbeat")]
+    Heartbeat(Heartbeat),
+}
+
+/// Errors raised while decoding a frame body into a typed message.
+#[derive(Debug, thiserror::Error)]
+pub enum WireError {
+    #[error("invalid JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("message is not a JSON object")]
+    NotAnObject,
+
+    #[error("bad or missing jsonrpc version: {0:?}")]
+    BadVersion(String),
+
+    #[error("unrecognized message shape")]
+    UnrecognizedMessage,
+}

--- a/a2a-stdio/tests/loopback.rs
+++ b/a2a-stdio/tests/loopback.rs
@@ -1,0 +1,373 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crate's client talking to this crate's server.
+//!
+//! The unit tests on either side script their peer by hand, which shows that
+//! each half matches one reading of the spec but not that the two readings
+//! agree. Here the only thing between them is a pair of in-memory pipes, so a
+//! disagreement about framing, correlation, or lifecycle shows up as a hang or
+//! a wrong answer rather than as two tests that both pass.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use a2a::*;
+use a2a_client::{ServiceParams, Transport};
+use a2a_server::{AgentExecutor, DefaultRequestHandler, ExecutorContext, InMemoryTaskStore};
+use a2a_stdio::client::{ClientConfig, StdioTransport};
+use a2a_stdio::metadata::BINDING_URI;
+use a2a_stdio::server::{ServerConfig, Startup, serve_on};
+use a2a_stdio::session::ExitCode;
+use a2a_stdio::wire::Variant;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+
+const SESSION_ID: &str = "loopback-session";
+const LAUNCH_DIGEST: &str = "sha256:test";
+const PIPE: usize = 64 * 1024;
+
+/// Metadata key the agent reports its received 4.1 parameters under.
+const OBSERVED: &str = "test/serviceParams";
+
+/// Emits the 8.2 shape: an initial `Task`, then a terminal status update.
+///
+/// The task echoes the service parameters the agent was handed, which is the
+/// only way a test on the client side can see what survived the trip.
+struct ScriptedAgent;
+
+impl AgentExecutor for ScriptedAgent {
+    fn execute(
+        &self,
+        ctx: ExecutorContext,
+    ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        let (task_id, context_id) = ctx.task_info();
+        let observed: Value = ctx
+            .service_params
+            .iter()
+            .map(|(k, v)| (k.clone(), json!(v)))
+            .collect::<serde_json::Map<_, _>>()
+            .into();
+        let task = Task {
+            id: task_id.clone(),
+            context_id: context_id.clone(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: ctx.message,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: Some(HashMap::from([(OBSERVED.to_string(), observed)])),
+        };
+        let done = TaskStatusUpdateEvent {
+            task_id,
+            context_id,
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: None,
+                timestamp: None,
+            },
+            metadata: None,
+        };
+        Box::pin(futures::stream::iter(vec![
+            Ok(StreamResponse::Task(task)),
+            Ok(StreamResponse::StatusUpdate(done)),
+        ]))
+    }
+
+    fn cancel(&self, ctx: ExecutorContext) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        let (task_id, context_id) = ctx.task_info();
+        Box::pin(futures::stream::once(async move {
+            Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                task_id,
+                context_id,
+                status: TaskStatus {
+                    state: TaskState::Canceled,
+                    message: None,
+                    timestamp: None,
+                },
+                metadata: None,
+            }))
+        }))
+    }
+}
+
+struct Loopback {
+    client: StdioTransport,
+    server: JoinHandle<ExitCode>,
+}
+
+impl Loopback {
+    /// Shut down the way 2.4 prescribes and report the agent's exit code.
+    async fn shutdown(self) -> ExitCode {
+        self.client.destroy().await.expect("destroy failed");
+        tokio::time::timeout(Duration::from_secs(5), self.server)
+            .await
+            .expect("the agent did not exit after STDIN closed")
+            .expect("the agent panicked")
+    }
+}
+
+async fn loopback() -> Loopback {
+    // Two pairs, because a child's STDIN and STDOUT are separate objects and
+    // closing one direction must not close the other.
+    let (client_read, server_write) = tokio::io::duplex(PIPE);
+    let (server_read, client_write) = tokio::io::duplex(PIPE);
+
+    let handler = DefaultRequestHandler::new(ScriptedAgent, InMemoryTaskStore::new())
+        .with_capabilities(AgentCapabilities {
+            streaming: Some(true),
+            ..Default::default()
+        });
+
+    let mut session_params = ServiceParams::new();
+    session_params.insert("a2a-version".into(), vec!["1.0".into()]);
+
+    let server = tokio::spawn(serve_on(
+        server_read,
+        server_write,
+        Startup {
+            session_id: SESSION_ID.into(),
+            session_params,
+        },
+        handler,
+        ServerConfig {
+            launch_digest: Some(LAUNCH_DIGEST.into()),
+            ..ServerConfig::default()
+        },
+    ));
+
+    let client = StdioTransport::attach(
+        client_read,
+        client_write,
+        SESSION_ID,
+        ClientConfig::default(),
+    )
+    .await
+    .expect("handshake failed");
+
+    Loopback { client, server }
+}
+
+fn hello() -> SendMessageRequest {
+    SendMessageRequest {
+        message: Message::new(Role::User, vec![Part::text("hello")]),
+        configuration: None,
+        metadata: None,
+        tenant: None,
+    }
+}
+
+/// 9.6: the server stamps the local session onto everything it emits, and it
+/// has to survive the client's decode to be of any use.
+#[track_caller]
+fn assert_bound(metadata: &Option<HashMap<String, Value>>) {
+    let binding = metadata
+        .as_ref()
+        .and_then(|m| m.get(BINDING_URI))
+        .expect("no session binding in metadata");
+    assert_eq!(binding["sessionId"], json!(SESSION_ID));
+    assert_eq!(binding["variant"], json!("stdio-json"));
+    assert_eq!(binding["launchDigest"], json!(LAUNCH_DIGEST));
+    assert!(binding["pid"].is_number(), "pid should be present");
+}
+
+#[track_caller]
+fn task_of(response: SendMessageResponse) -> Task {
+    match response {
+        SendMessageResponse::Task(task) => task,
+        other => panic!("expected a task, got {other:?}"),
+    }
+}
+
+/// What the agent reported seeing under [`OBSERVED`].
+#[track_caller]
+fn observed(task: &Task) -> &Value {
+    &task.metadata.as_ref().expect("no metadata")[OBSERVED]
+}
+
+#[tokio::test]
+async fn the_handshake_agrees_on_stdio_json() {
+    let lb = loopback().await;
+    assert_eq!(lb.client.session_id(), SESSION_ID);
+    assert_eq!(
+        lb.client.variant(),
+        Variant::Json,
+        "both halves must reach the same variant (2.2)"
+    );
+    assert!(
+        lb.client
+            .server_features()
+            .contains(&"streaming".to_string()),
+        "features advertised by the server should reach the client"
+    );
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn a_unary_call_crosses_the_binding() {
+    let lb = loopback().await;
+    let task = task_of(
+        lb.client
+            .send_message(&ServiceParams::new(), &hello())
+            .await
+            .expect("send_message failed"),
+    );
+    assert_eq!(task.status.state, TaskState::Completed);
+    assert_bound(&task.metadata);
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn a_stream_crosses_the_binding_in_order_and_terminates() {
+    let lb = loopback().await;
+    let mut stream = lb
+        .client
+        .send_streaming_message(&ServiceParams::new(), &hello())
+        .await
+        .expect("send_streaming_message failed");
+
+    let mut kinds = Vec::new();
+    while let Some(item) = stream.next().await {
+        kinds.push(match item.expect("stream item failed") {
+            StreamResponse::Task(t) => {
+                assert_bound(&t.metadata);
+                "task"
+            }
+            StreamResponse::StatusUpdate(s) => {
+                // 9.6 lists Task, Message and Artifact, so an update event is
+                // left alone even mid-stream. Asserted rather than skipped
+                // because stamping it would be the easy mistake to make.
+                assert!(s.metadata.is_none(), "an update event is not stamped");
+                "status"
+            }
+            StreamResponse::Message(_) => "message",
+            StreamResponse::ArtifactUpdate(_) => "artifact",
+        });
+    }
+    // 8.2 ordering, and the end came from `streamEnd` rather than a lost pipe:
+    // the session is still usable below.
+    assert_eq!(kinds, ["task", "status"]);
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn two_calls_share_one_pipe_pair() {
+    // 3.6: correlation by id is the only thing keeping these apart.
+    let lb = loopback().await;
+    let params = ServiceParams::new();
+
+    let created = task_of(lb.client.send_message(&params, &hello()).await.unwrap());
+
+    let fetched = lb
+        .client
+        .get_task(
+            &params,
+            &GetTaskRequest {
+                id: created.id.clone(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .expect("get_task failed");
+
+    assert_eq!(fetched.id, created.id);
+    assert_bound(&fetched.metadata);
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn a_server_error_keeps_its_code_across_the_binding() {
+    // 7.2: the numeric code is the JSON-RPC binding's, so it must survive the
+    // trip rather than arrive as a generic internal error.
+    let lb = loopback().await;
+    let err = lb
+        .client
+        .get_task(
+            &ServiceParams::new(),
+            &GetTaskRequest {
+                id: "no-such-task".into(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .expect_err("a missing task should be an error");
+
+    assert_eq!(err.code, error_code::TASK_NOT_FOUND);
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn cancelling_a_stream_leaves_the_session_usable() {
+    // 8.5: the point of a `cancelStream` frame is that it stops one stream
+    // instead of tearing down the pipe the way closing an SSE response would.
+    let lb = loopback().await;
+    let params = ServiceParams::new();
+
+    let created = task_of(lb.client.send_message(&params, &hello()).await.unwrap());
+
+    let stream = lb
+        .client
+        .subscribe_to_task(
+            &params,
+            &SubscribeToTaskRequest {
+                id: created.id.clone(),
+                tenant: None,
+            },
+        )
+        .await
+        .expect("subscribe_to_task failed");
+    drop(stream);
+
+    let fetched = lb
+        .client
+        .get_task(
+            &params,
+            &GetTaskRequest {
+                id: created.id.clone(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .expect("the session should have survived the cancel");
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}
+
+#[tokio::test]
+async fn session_params_apply_and_a_request_overrides_them() {
+    // 4.1. Both halves are checked in one session because the interesting part
+    // is the difference between them, not either alone.
+    let lb = loopback().await;
+
+    let defaulted = task_of(
+        lb.client
+            .send_message(&ServiceParams::new(), &hello())
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        observed(&defaulted)["a2a-version"],
+        json!(["1.0"]),
+        "a request naming no parameters inherits the spawn's"
+    );
+
+    let mut overrides = ServiceParams::new();
+    overrides.insert("a2a-version".into(), vec!["2.0".into()]);
+    overrides.insert("a2a-tenant".into(), vec!["acme".into()]);
+    let overridden = task_of(lb.client.send_message(&overrides, &hello()).await.unwrap());
+    assert_eq!(
+        observed(&overridden)["a2a-version"],
+        json!(["2.0"]),
+        "a request-scoped value replaces the session's"
+    );
+    assert_eq!(observed(&overridden)["a2a-tenant"], json!(["acme"]));
+
+    assert_eq!(lb.shutdown().await, ExitCode::Ok);
+}

--- a/a2a/src/jsonrpc.rs
+++ b/a2a/src/jsonrpc.rs
@@ -73,7 +73,7 @@ pub struct JsonRpcError {
 // ---------------------------------------------------------------------------
 
 /// A JSON-RPC ID that can be a string, integer, or null.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JsonRpcId {
     String(String),
     Number(i64),

--- a/a2a/src/types.rs
+++ b/a2a/src/types.rs
@@ -690,6 +690,8 @@ pub const TRANSPORT_PROTOCOL_GRPC: &str = "GRPC";
 pub const TRANSPORT_PROTOCOL_HTTP_JSON: &str = "HTTP+JSON";
 /// SLIMRPC transport protocol constant.
 pub const TRANSPORT_PROTOCOL_SLIMRPC: &str = "SLIMRPC";
+/// STDIO transport protocol constant.
+pub const TRANSPORT_PROTOCOL_STDIO: &str = "STDIO";
 
 /// Protocol version string (e.g., "1.0").
 pub type ProtocolVersion = String;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,13 +24,6 @@ path = "src/helloworld_tls/server.rs"
 name = "helloworld-tls-client"
 path = "src/helloworld_tls/client.rs"
 
-[[bin]]
-name = "stdio-agent"
-path = "src/stdio/agent.rs"
-[[bin]]
-name = "stdio-host"
-path = "src/stdio/host.rs"
-
 [dependencies]
 a2a = { workspace = true }
 a2a-client = { workspace = true, features = ["rustls-tls"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,13 @@ path = "src/helloworld_tls/server.rs"
 name = "helloworld-tls-client"
 path = "src/helloworld_tls/client.rs"
 
+[[bin]]
+name = "stdio-agent"
+path = "src/stdio/agent.rs"
+[[bin]]
+name = "stdio-host"
+path = "src/stdio/host.rs"
+
 [dependencies]
 a2a = { workspace = true }
 a2a-client = { workspace = true, features = ["rustls-tls"] }


### PR DESCRIPTION
## Summary

Adds a reference implementation of the A2A STDIO protocol binding through a new `a2a-stdio` crate.

The implementation enables an A2A client to launch or attach to an agent process and communicate over `stdin`/`stdout` using framed JSON-RPC messages.

Closes: #15

## What changed

- Added the `a2a-stdio` workspace crate with client and server implementations.
- Added `Content-Length`-based message framing with configurable frame and header limits.
- Implemented STDIO session handshake and `stdio-json` variant negotiation.
- Added support for:
  - Unary A2A requests
  - Streaming requests and ordered stream responses
  - Concurrent request correlation using JSON-RPC IDs
  - Stream cancellation and graceful shutdown
  - Heartbeat and control frames
  - Session-scoped service parameters with per-request overrides
- Added session-binding metadata to emitted tasks, messages, and artifacts.
- Added secure child-process launch configuration with an isolated environment by default.
- Extracted shared request dispatch logic from the HTTP JSON-RPC server so it can be reused by the STDIO binding.
- Added the `STDIO` transport protocol constant.
- Made the shared A2A wire-error conversion helper publicly reusable.
- Added unit and end-to-end loopback tests covering negotiation, framing, unary calls, streaming, cancellation, errors, concurrency, metadata, and shutdown behavior.

## Current scope

This PR implements the `stdio-json` serialization variant. The `stdio-proto` variant is represented during negotiation but is not yet advertised or supported.

## Validation

- `cargo test -p a2a-stdio` — 100 tests passed
- `cargo fmt --all -- --check`