### PR TITLE
fix(server): avoid buffering without subscribers

### DIFF
--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -49,17 +49,29 @@ impl ActiveExecution {
         (receiver, state.snapshot_task.clone(), state.sequence)
     }
 
-    async fn publish(&self, result: Result<StreamResponse, A2AError>, snapshot_task: Option<Task>) {
-        let event = {
+    async fn publish(
+        &self,
+        result: Result<&StreamResponse, &A2AError>,
+        snapshot_task: Option<Task>,
+    ) {
+        let sequence = {
             let mut state = self.state.write().await;
             if let Some(task) = snapshot_task {
                 state.snapshot_task = Some(task);
             }
             state.sequence += 1;
-            ExecutionEvent {
-                sequence: state.sequence,
-                result,
-            }
+            state.sequence
+        };
+
+        // Task state remains available for a later subscription, but transient
+        // events do not need to be allocated when no subscriber is listening.
+        if self.sender.receiver_count() == 0 {
+            return;
+        }
+
+        let event = ExecutionEvent {
+            sequence,
+            result: result.cloned().map_err(Clone::clone),
         };
         let _ = self.sender.send(event);
     }
@@ -319,22 +331,22 @@ async fn drive_execution(
                         )
                         .await
                         {
-                            active.publish(Err(error), None).await;
+                            active.publish(Err(&error), None).await;
                             break;
                         }
-                        active.publish(Ok(event.clone()), updated_task).await;
+                        active.publish(Ok(&event), updated_task).await;
                         if is_terminal_event(&event) {
                             break;
                         }
                     }
                     Err(error) => {
-                        active.publish(Err(error), None).await;
+                        active.publish(Err(&error), None).await;
                         break;
                     }
                 }
             }
             Err(error) => {
-                active.publish(Err(error), None).await;
+                active.publish(Err(&error), None).await;
                 break;
             }
         }
@@ -690,7 +702,7 @@ impl RequestHandler for DefaultRequestHandler {
                     .await?;
 
                     if let Some(active) = &active_execution {
-                        active.publish(Ok(event.clone()), updated_task).await;
+                        active.publish(Ok(&event), updated_task).await;
                     }
 
                     if is_terminal_event(&event) {
@@ -699,7 +711,7 @@ impl RequestHandler for DefaultRequestHandler {
                 }
                 Err(error) => {
                     if let Some(active) = &active_execution {
-                        active.publish(Err(error.clone()), None).await;
+                        active.publish(Err(&error), None).await;
                     }
                     return Err(error);
                 }
@@ -1103,6 +1115,115 @@ mod tests {
         let mut stream = handler.send_streaming_message(&params, req).await.unwrap();
         let event = stream.next().await.unwrap().unwrap();
         assert!(matches!(event, StreamResponse::Task(_)));
+    }
+
+    #[tokio::test]
+    async fn test_stream_disconnect_preserves_execution_for_resubscription() {
+        use futures::StreamExt;
+
+        let (handler, release) = make_resumable_handler();
+        let params = ServiceParams::new();
+        let mut message = make_message();
+        message.task_id = Some("t-disconnect".into());
+        message.context_id = Some("c-disconnect".into());
+
+        let mut stream = handler
+            .send_streaming_message(
+                &params,
+                SendMessageRequest {
+                    message,
+                    configuration: None,
+                    metadata: None,
+                    tenant: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let initial = stream.next().await.unwrap().unwrap();
+        match initial {
+            StreamResponse::Task(task) => assert_eq!(task.status.state, TaskState::Working),
+            _ => panic!("expected initial working task"),
+        }
+        drop(stream);
+
+        let mut resumed = handler
+            .subscribe_to_task(
+                &params,
+                SubscribeToTaskRequest {
+                    id: "t-disconnect".into(),
+                    tenant: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let snapshot = resumed.next().await.unwrap().unwrap();
+        match snapshot {
+            StreamResponse::Task(task) => assert_eq!(task.status.state, TaskState::Working),
+            _ => panic!("expected working task snapshot"),
+        }
+
+        release.notify_waiters();
+
+        let terminal = resumed.next().await.unwrap().unwrap();
+        match terminal {
+            StreamResponse::Task(task) => {
+                assert_eq!(task.status.state, TaskState::Completed)
+            }
+            _ => panic!("expected terminal task"),
+        }
+        assert!(resumed.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_active_execution_keeps_snapshot_without_subscribers() {
+        let task = Task {
+            id: "t-buffering".into(),
+            context_id: "c-buffering".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        let active = ActiveExecution::new(task.clone());
+
+        let event = StreamResponse::Task(task.clone());
+        active.publish(Ok(&event), Some(task)).await;
+
+        let (mut receiver, snapshot_task, sequence) = active.resubscribe().await;
+        assert_eq!(snapshot_task.unwrap().id, "t-buffering");
+        assert_eq!(sequence, 1);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_active_execution_publishes_errors_to_subscribers() {
+        let task = Task {
+            id: "t-buffering-error".into(),
+            context_id: "c-buffering-error".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        let active = ActiveExecution::new(task);
+        let mut receiver = active.subscribe();
+        let error = A2AError::internal("execution failed");
+
+        active.publish(Err(&error), None).await;
+
+        let event = receiver.recv().await.unwrap();
+        assert_eq!(event.sequence, 1);
+        assert_eq!(event.result.unwrap_err().code, error.code);
     }
 
     #[tokio::test]

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -1254,6 +1254,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_active_execution_publishes_events_with_snapshot_updates() {
+        let initial_task = Task {
+            id: "t-snapshot-update".into(),
+            context_id: "c-snapshot-update".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        let active = ActiveExecution::new(initial_task.clone());
+        let mut receiver = active.subscribe();
+
+        let updated_task = Task {
+            id: "t-snapshot-update".into(),
+            context_id: "c-snapshot-update".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+
+        let event = StreamResponse::Task(updated_task.clone());
+        active.publish(Ok(&event), Some(updated_task.clone())).await;
+
+        // Verify event was published to subscriber
+        let published = receiver.recv().await.unwrap();
+        assert_eq!(published.sequence, 1);
+        match published.result {
+            Ok(StreamResponse::Task(task)) => {
+                assert_eq!(task.id, "t-snapshot-update");
+            }
+            _ => panic!("expected Ok(Task) event"),
+        }
+
+        // Verify snapshot was updated
+        let (_, snapshot_task, sequence) = active.resubscribe().await;
+        assert_eq!(snapshot_task.unwrap().id, "t-snapshot-update");
+        assert_eq!(sequence, 1);
+    }
+
+
+
+    #[tokio::test]
     async fn test_get_task_not_found() {
         let handler = make_handler();
         let params = ServiceParams::new();

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -1227,6 +1227,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_active_execution_drops_errors_without_subscribers() {
+        let task = Task {
+            id: "t-error-no-sub".into(),
+            context_id: "c-error-no-sub".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        let active = ActiveExecution::new(task.clone());
+        let error = A2AError::internal("execution failed");
+
+        // Publish error without any subscribers
+        active.publish(Err(&error), Some(task.clone())).await;
+
+        // Resubscribe to verify snapshot was updated but no event was buffered
+        let (mut receiver, snapshot_task, sequence) = active.resubscribe().await;
+        assert_eq!(snapshot_task.unwrap().id, "t-error-no-sub");
+        assert_eq!(sequence, 1);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
     async fn test_get_task_not_found() {
         let handler = make_handler();
         let params = ServiceParams::new();

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -1302,8 +1302,6 @@ mod tests {
         assert_eq!(sequence, 1);
     }
 
-
-
     #[tokio::test]
     async fn test_get_task_not_found() {
         let handler = make_handler();

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -1303,6 +1303,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_active_execution_broadcasts_to_multiple_subscribers() {
+        let task = Task {
+            id: "t-multi-sub".into(),
+            context_id: "c-multi-sub".into(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        let active = ActiveExecution::new(task.clone());
+
+        // Create two subscribers
+        let mut sub1 = active.subscribe();
+        let mut sub2 = active.subscribe();
+
+        let event = StreamResponse::Task(task);
+        active.publish(Ok(&event), None).await;
+
+        // Both subscribers should receive the same event
+        let evt1 = sub1.recv().await.unwrap();
+        let evt2 = sub2.recv().await.unwrap();
+
+        assert_eq!(evt1.sequence, 1);
+        assert_eq!(evt2.sequence, 1);
+        assert!(matches!(evt1.result, Ok(StreamResponse::Task(_))));
+        assert!(matches!(evt2.result, Ok(StreamResponse::Task(_))));
+    }
+
+    #[tokio::test]
     async fn test_get_task_not_found() {
         let handler = make_handler();
         let params = ServiceParams::new();

--- a/itk/src/main.rs
+++ b/itk/src/main.rs
@@ -192,7 +192,7 @@ impl ItkExecutor {
 
         // Build client factory with gRPC support
         let client = A2AClientFactory::builder()
-            .register(Arc::new(GrpcTransportFactory {}))
+            .register(Arc::new(GrpcTransportFactory::new()))
             .preferred_bindings(Self::transport_preference(&call.transport))
             .build()
             .create_from_card(&card)


### PR DESCRIPTION
Fixes #148.

Avoids cloning and buffering transient stream events when no subscriber is connected, while preserving task execution, persistence, and resubscription semantics.

Executor-owned cleanup for abandoned long-running executions is tracked separately in #149.