### PR TITLE
feat: add a2a-transport-slimrpc CLI plugin crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "a2acli-transport-slimrpc"
+version = "0.1.0"
+dependencies = [
+ "a2a-client-lf",
+ "a2a-grpc",
+ "a2a-lf",
+ "a2a-pb",
+ "a2a-server-lf",
+ "a2a-slimrpc",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
+ "agntcy-slim-datapath",
+ "agntcy-slim-service",
+ "async-trait",
+ "clap",
+ "futures",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-tls",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "agntcy-slim-auth"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "a2a-grpc",
     "a2a-slimrpc",
     "a2acli",
+    "a2acli-transport-slimrpc",
     "examples",
     "itk",
 ]
@@ -19,6 +20,7 @@ default-members = [
     "a2a-grpc",
     "a2a-slimrpc",
     "a2acli",
+    "a2acli-transport-slimrpc",
     "examples",
 ]
 

--- a/a2acli-transport-slimrpc/Cargo.toml
+++ b/a2acli-transport-slimrpc/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "a2acli-transport-slimrpc"
+version = "0.1.0"
+description = "SLIMRPC transport plugin for a2a-cli — implements the pluggable transport contract"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "a2a-transport-slimrpc"
+path = "src/main.rs"
+
+[dependencies]
+a2a = { workspace = true }
+a2a-client = { workspace = true }
+a2a-server = { workspace = true }
+a2a-pb = { workspace = true }
+a2a-grpc = { workspace = true }
+a2a-slimrpc = { workspace = true }
+slim_config = { workspace = true }
+slim_service = { workspace = true }
+slim_auth = { workspace = true }
+slim_datapath = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tonic-tls = { workspace = true }
+rcgen = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { version = "4.5", features = ["derive", "env"] }
+serde_yaml = "0.9"
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = [
+    "a2a-grpc/rustls-tls",
+    "tonic-tls/rustls",
+]

--- a/a2acli-transport-slimrpc/src/error.rs
+++ b/a2acli-transport-slimrpc/src/error.rs
@@ -1,0 +1,44 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PluginError {
+    #[error("config file not found: A2A_SLIMRPC_PLUGIN_CONFIG env var is not set")]
+    ConfigEnvMissing,
+
+    #[error("failed to read config file '{path}': {source}")]
+    ConfigRead {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse config file '{path}': {source}")]
+    ConfigParse {
+        path: String,
+        #[source]
+        source: serde_yaml::Error,
+    },
+
+    #[error("auth config error: {0}")]
+    Auth(#[from] slim_config::auth::ConfigAuthError),
+
+    #[error("SLIM service error: {0}")]
+    Slim(String),
+
+    #[error("TLS setup error: {0}")]
+    Tls(String),
+
+    #[error("server bind error: {0}")]
+    Bind(#[from] std::io::Error),
+
+    #[error("handshake write error: {0}")]
+    Handshake(String),
+
+    #[error("invalid endpoint: {0}")]
+    InvalidEndpoint(String),
+
+    #[error("unsupported binding '{0}': expected grpc, jsonrpc, or http+json")]
+    UnsupportedBinding(String),
+}

--- a/a2acli-transport-slimrpc/src/info.rs
+++ b/a2acli-transport-slimrpc/src/info.rs
@@ -1,0 +1,27 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Info {
+    pub name: &'static str,
+    pub version: &'static str,
+    pub description: &'static str,
+    pub protocol: &'static str,
+    pub binding: &'static str,
+}
+
+pub fn run() -> Result<(), crate::error::PluginError> {
+    let info = Info {
+        name: "slimrpc",
+        version: env!("CARGO_PKG_VERSION"),
+        description: "SLIMRPC transport plugin for a2a-cli",
+        protocol: a2a::VERSION,
+        binding: a2a::TRANSPORT_PROTOCOL_GRPC,
+    };
+    let json = serde_json::to_string(&info)
+        .map_err(|e| crate::error::PluginError::Handshake(e.to_string()))?;
+    println!("{json}");
+    Ok(())
+}

--- a/a2acli-transport-slimrpc/src/main.rs
+++ b/a2acli-transport-slimrpc/src/main.rs
@@ -1,0 +1,59 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+mod error;
+mod info;
+mod serve;
+mod tls;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "a2a-transport-slimrpc",
+    version,
+    about = "SLIMRPC transport plugin for a2a-cli"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Start the loopback proxy server for a given SLIMRPC endpoint.
+    Serve {
+        /// SLIMRPC upstream endpoint (e.g. slim://org/namespace/agent).
+        #[arg(long)]
+        endpoint: String,
+    },
+    /// Print plugin metadata as JSON and exit.
+    Info,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "warn".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Command::Serve { endpoint } => serve::run(&endpoint).await,
+        Command::Info => info::run(),
+    };
+
+    if let Err(e) = result {
+        eprintln!("a2a-transport-slimrpc: {e}");
+        std::process::exit(1);
+    }
+}

--- a/a2acli-transport-slimrpc/src/serve.rs
+++ b/a2acli-transport-slimrpc/src/serve.rs
@@ -1,0 +1,375 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{self, BufRead};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use a2a::*;
+use a2a_client::Transport;
+use a2a_client::transport::ServiceParams;
+use a2a_grpc::GrpcHandler;
+use a2a_pb::proto::a2a_service_server::A2aServiceServer;
+use a2a_server::RequestHandler;
+use a2a_slimrpc::{SlimRpcTransport, parse_slimrpc_target};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use slim_config::auth::identity::{IdentityProviderConfig, IdentityVerifierConfig};
+use slim_config::client::ClientConfig;
+use slim_datapath::api::ProtoName;
+use slim_service::service::{Service, ServiceBuilder};
+use tonic::transport::server::TcpIncoming;
+use tonic_tls::rustls::TlsIncoming;
+use uuid::Uuid;
+
+use crate::error::PluginError;
+use crate::tls::generate_loopback_tls;
+
+const TOKEN_HEADER: &str = "a2a-plugin-token";
+
+// ── Config file schema ─────────────────────────────────────────────────────────
+//
+// Example:
+//   client:
+//     endpoint: "grpc://slim-gateway:46357"
+//     # optional: tls, auth, backoff, etc. (slim_config::ClientConfig)
+//   app:
+//     name: "org/namespace/agent"
+//     identity_provider:
+//       type: shared_secret
+//       id: "my-id"
+//       data: "secret"
+//     identity_verifier:
+//       type: shared_secret
+//       id: "my-id"
+//       data: "secret"
+
+#[derive(Debug, Deserialize)]
+pub struct PluginConfig {
+    pub client: ClientConfig,
+    pub app: AppConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AppConfig {
+    /// SLIM app name in the form "org/namespace/agent".
+    pub name: String,
+    pub identity_provider: IdentityProviderConfig,
+    pub identity_verifier: IdentityVerifierConfig,
+}
+
+// ── Handshake wire types ───────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct Handshake {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "payload")]
+    endpoint: Option<EndpointPayload>,
+}
+
+#[derive(Serialize)]
+struct EndpointPayload {
+    address: String,
+    binding: &'static str,
+    protocol: &'static str,
+    token: String,
+    #[serde(rename = "certPem")]
+    cert_pem: String,
+}
+
+fn write_handshake(hs: &Handshake) -> Result<(), PluginError> {
+    let json = serde_json::to_string(hs)
+        .map_err(|e| PluginError::Handshake(e.to_string()))?;
+    println!("{json}");
+    Ok(())
+}
+
+// ── Transport → RequestHandler adapter ────────────────────────────────────────
+
+/// Adapts SlimRpcTransport (a client Transport) into a server RequestHandler,
+/// forwarding all calls while enforcing the per-launch plugin token.
+struct TransportHandler {
+    transport: SlimRpcTransport,
+    token: String,
+}
+
+impl TransportHandler {
+    fn new(transport: SlimRpcTransport, token: String) -> Self {
+        Self { transport, token }
+    }
+
+    fn check_token(&self, params: &ServiceParams) -> Result<(), A2AError> {
+        let provided = params.get(TOKEN_HEADER);
+        match provided {
+            Some(values) if values.len() == 1 && values[0] == self.token => Ok(()),
+            _ => Err(A2AError::new(
+                error_code::INVALID_REQUEST,
+                "invalid or missing plugin token",
+            )),
+        }
+    }
+
+    fn forward_params(&self, params: &ServiceParams) -> ServiceParams {
+        // Strip the plugin token before forwarding upstream
+        let mut fwd = ServiceParams::new();
+        for (k, v) in params.iter() {
+            if k.eq_ignore_ascii_case(TOKEN_HEADER) {
+                continue;
+            }
+            fwd.insert(k.clone(), v.clone());
+        }
+        fwd
+    }
+}
+
+#[async_trait]
+impl RequestHandler for TransportHandler {
+    async fn send_message(
+        &self,
+        params: &ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<SendMessageResponse, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .send_message(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn send_streaming_message(
+        &self,
+        params: &ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .send_streaming_message(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn get_task(
+        &self,
+        params: &ServiceParams,
+        req: GetTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .get_task(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn list_tasks(
+        &self,
+        params: &ServiceParams,
+        req: ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .list_tasks(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn cancel_task(
+        &self,
+        params: &ServiceParams,
+        req: CancelTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .cancel_task(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn subscribe_to_task(
+        &self,
+        params: &ServiceParams,
+        req: SubscribeToTaskRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .subscribe_to_task(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn create_push_config(
+        &self,
+        params: &ServiceParams,
+        req: TaskPushNotificationConfig,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .create_push_config(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn get_push_config(
+        &self,
+        params: &ServiceParams,
+        req: GetTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .get_push_config(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn list_push_configs(
+        &self,
+        params: &ServiceParams,
+        req: ListTaskPushNotificationConfigsRequest,
+    ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .list_push_configs(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn delete_push_config(
+        &self,
+        params: &ServiceParams,
+        req: DeleteTaskPushNotificationConfigRequest,
+    ) -> Result<(), A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .delete_push_config(&self.forward_params(params), &req)
+            .await
+    }
+
+    async fn get_extended_agent_card(
+        &self,
+        params: &ServiceParams,
+        req: GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard, A2AError> {
+        self.check_token(params)?;
+        self.transport
+            .get_extended_agent_card(&self.forward_params(params), &req)
+            .await
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Parse an app name of the form "org/namespace/agent" into a SLIM `ProtoName`.
+fn parse_proto_name(name: &str) -> Result<ProtoName, PluginError> {
+    let parts: Vec<&str> = name.splitn(3, '/').collect();
+    match parts.as_slice() {
+        [org, namespace, agent] if !org.is_empty() && !namespace.is_empty() && !agent.is_empty() => {
+            Ok(ProtoName::from_strings([*org, *namespace, *agent]))
+        }
+        _ => Err(PluginError::InvalidEndpoint(format!(
+            "app.name '{name}' must be 'org/namespace/agent'"
+        ))),
+    }
+}
+
+// ── Serve entry point ──────────────────────────────────────────────────────────
+
+pub async fn run(endpoint: &str) -> Result<(), PluginError> {
+    // 1. Load config
+    let config_path = std::env::var("A2A_SLIMRPC_PLUGIN_CONFIG")
+        .map_err(|_| PluginError::ConfigEnvMissing)?;
+    let config_bytes = std::fs::read(&config_path).map_err(|e| PluginError::ConfigRead {
+        path: config_path.clone(),
+        source: e,
+    })?;
+    let config: PluginConfig = serde_yaml::from_slice(&config_bytes).map_err(|e| {
+        PluginError::ConfigParse {
+            path: config_path.clone(),
+            source: e,
+        }
+    })?;
+
+    // 2. Parse SLIMRPC remote target
+    let remote = parse_slimrpc_target(endpoint).map_err(|e| {
+        PluginError::InvalidEndpoint(format!("{endpoint}: {}", e.message))
+    })?;
+
+    // 3. Build auth provider + verifier from app config
+    let provider = config.app.identity_provider.build_auth_provider()?;
+    let verifier = config.app.identity_verifier.build_auth_verifier()?;
+
+    // 4. Build SLIM Service + connect to gateway
+    let kind = ServiceBuilder::kind();
+    let id = slim_config::component::id::ID::new_with_name(kind, &config.app.name)
+        .map_err(|e| PluginError::Slim(format!("invalid service ID: {e}")))?;
+    let service = Service::new(id);
+
+    let conn_id = service
+        .connect(&config.client)
+        .await
+        .map_err(|e| PluginError::Slim(format!("SLIM gateway connect failed: {e}")))?;
+
+    // 5. Build SlimApp + transport
+    // Parse the app name (org/namespace/agent) into SLIM's ProtoName components.
+    let app_name = parse_proto_name(&config.app.name)?;
+    let (slim_app, _notifications) = service
+        .create_app(&app_name, provider, verifier)
+        .map_err(|e| PluginError::Slim(format!("create_app failed: {e}")))?;
+    let slim_app = Arc::new(slim_app);
+
+    let transport = SlimRpcTransport::new_with_connection(slim_app, remote, Some(conn_id));
+
+    // 6. Generate per-launch token + TLS cert
+    let token = Uuid::new_v4().to_string();
+    let tls = generate_loopback_tls()?;
+
+    // 7. Bind loopback TCP + wrap in TLS
+    // Bind on :0 to get a random port, then record the assigned address.
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let std_listener = std::net::TcpListener::bind(addr).map_err(PluginError::Bind)?;
+    let local_addr = std_listener.local_addr().map_err(PluginError::Bind)?;
+    std_listener.set_nonblocking(true).map_err(PluginError::Bind)?;
+    let tokio_listener = tokio::net::TcpListener::from_std(std_listener).map_err(PluginError::Bind)?;
+
+    let tcp_incoming = TcpIncoming::from(tokio_listener);
+    let tls_incoming = TlsIncoming::new(tcp_incoming, tls.server_config);
+
+    // 8. Build gRPC service
+    let handler = Arc::new(TransportHandler::new(transport, token.clone()));
+    let grpc_service = A2aServiceServer::new(GrpcHandler::new(handler));
+
+    // 9. Print handshake
+    let hs = Handshake {
+        success: true,
+        error: None,
+        endpoint: Some(EndpointPayload {
+            address: local_addr.to_string(),
+            binding: TRANSPORT_PROTOCOL_GRPC,
+            protocol: VERSION,
+            token,
+            cert_pem: tls.cert_pem,
+        }),
+    };
+    write_handshake(&hs)?;
+
+    // 10. Serve until stdin closes (CLI parent exit signal)
+    let serve_fut = tonic::transport::Server::builder()
+        .add_service(grpc_service)
+        .serve_with_incoming(tls_incoming);
+
+    tokio::select! {
+        result = serve_fut => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "gRPC proxy server exited with error");
+            }
+        }
+        _ = wait_stdin_close() => {
+            tracing::debug!("stdin closed, shutting down");
+        }
+    }
+
+    Ok(())
+}
+
+async fn wait_stdin_close() {
+    tokio::task::spawn_blocking(|| {
+        let stdin = io::stdin();
+        let mut reader = stdin.lock();
+        let mut buf = Vec::new();
+        let _ = reader.read_until(0, &mut buf);
+    })
+    .await
+    .ok();
+}

--- a/a2acli-transport-slimrpc/src/tls.rs
+++ b/a2acli-transport-slimrpc/src/tls.rs
@@ -1,0 +1,53 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+use rcgen::{CertificateParams, DistinguishedName, KeyPair};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+use crate::error::PluginError;
+
+pub struct LoopbackTls {
+    pub cert_pem: String,
+    pub server_config: std::sync::Arc<rustls::ServerConfig>,
+}
+
+/// Generate a self-signed cert/key for the loopback gRPC proxy.
+/// The cert PEM is sent in the handshake so the CLI can pin it.
+pub fn generate_loopback_tls() -> Result<LoopbackTls, PluginError> {
+    let key_pair = KeyPair::generate().map_err(|e| PluginError::Tls(e.to_string()))?;
+
+    let mut params = CertificateParams::default();
+    params.distinguished_name = DistinguishedName::new();
+    params.subject_alt_names = vec![rcgen::SanType::IpAddress(
+        "127.0.0.1".parse().expect("valid IP"),
+    )];
+
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(|e| PluginError::Tls(e.to_string()))?;
+
+    let cert_pem = cert.pem();
+    let key_pem = key_pair.serialize_pem();
+
+    let certs: Vec<CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut cert_pem.as_bytes())
+            .collect::<Result<_, _>>()
+            .map_err(|e| PluginError::Tls(format!("parse cert: {e}")))?;
+
+    let key: PrivateKeyDer<'static> = rustls_pemfile::private_key(&mut key_pem.as_bytes())
+        .map_err(|e| PluginError::Tls(format!("parse key: {e}")))?
+        .ok_or_else(|| PluginError::Tls("no private key in PEM".to_string()))?;
+
+    let mut server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| PluginError::Tls(format!("build server TLS config: {e}")))?;
+
+    // gRPC requires ALPN h2
+    server_config.alpn_protocols = vec![tonic_tls::ALPN_H2.to_vec()];
+
+    Ok(LoopbackTls {
+        cert_pem,
+        server_config: std::sync::Arc::new(server_config),
+    })
+}


### PR DESCRIPTION
## Summary

- Adds new `a2acli-transport-slimrpc` crate producing the `a2a-transport-slimrpc` binary
- Implements the pluggable transport contract from [a2aproject/a2a-cli#24](https://github.com/a2aproject/a2a-cli/pull/24), allowing the Go a2a-cli to use SLIMRPC without recompilation
- Drop the binary on PATH; the CLI discovers it automatically as `a2a-transport-slimrpc`

## How it works

The CLI launches `a2a-transport-slimrpc serve --endpoint <slim-url>`. The plugin:

1. Loads config from `$A2A_SLIMRPC_PLUGIN_CONFIG` (YAML file)
2. Connects to the SLIM gateway via `slim_config::ClientConfig`
3. Creates a `SlimRpcTransport` using the configured app identity
4. Starts a TLS gRPC loopback proxy on `127.0.0.1:0` (random port)
5. Writes a handshake JSON line to stdout with the address, token, and self-signed cert PEM
6. Runs until stdin closes (CLI parent exit signal)

The `info` subcommand prints plugin metadata for `a2a transport list`.

## Config file schema

```yaml
client:
  endpoint: "grpc://slim-gateway:46357"
  # full slim_config::ClientConfig (gateway auth, TLS, backoff, etc.)

app:
  name: "org/namespace/agent"
  identity_provider:
    type: shared_secret
    id: "my-id"
    data: "secret"
  identity_verifier:
    type: shared_secret
    id: "my-id"
    data: "secret"
```