### PR TITLE
a2a: enforce v1 task and discovery contracts

### DIFF
--- a/a2a-client/src/agent_card.rs
+++ b/a2a-client/src/agent_card.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 use a2a::{A2AError, AgentCard};
+use a2a_pb::protojson_conv;
 use reqwest::Client;
 
 /// Resolves agent cards from `.well-known/agent-card.json` endpoints.
@@ -39,8 +40,11 @@ impl AgentCardResolver {
             )));
         }
 
-        resp.json::<AgentCard>()
+        let value = resp
+            .json::<serde_json::Value>()
             .await
+            .map_err(|e| A2AError::internal(format!("failed to parse agent card: {e}")))?;
+        protojson_conv::from_value(value)
             .map_err(|e| A2AError::internal(format!("failed to parse agent card: {e}")))
     }
 }
@@ -98,5 +102,35 @@ mod tests {
 
         assert!(card.skills.is_empty());
         assert_eq!(card.supported_interfaces[0].protocol_binding, "JSONRPC");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_accepts_protojson_empty_security_scopes() {
+        let server = spawn_agent_card_server(
+            r#"{
+                "name": "Test Agent",
+                "description": "Canonical empty scope fixture",
+                "version": "1",
+                "supportedInterfaces": [{
+                    "url": "http://127.0.0.1:3000/jsonrpc",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0"
+                }],
+                "capabilities": {},
+                "defaultInputModes": ["text/plain"],
+                "defaultOutputModes": ["text/plain"],
+                "securitySchemes": {
+                    "peer": {"httpAuthSecurityScheme": {"scheme": "bearer"}}
+                },
+                "securityRequirements": [{"schemes": {"peer": {}}}]
+            }"#,
+        )
+        .await;
+        let resolver = AgentCardResolver::new(None);
+        let card = resolver
+            .resolve(&server)
+            .await
+            .expect("an empty generated StringList is a valid declared authentication scope");
+        assert!(card.security_requirements.unwrap()[0]["peer"].is_empty());
     }
 }

--- a/a2a-server/src/agent_card.rs
+++ b/a2a-server/src/agent_card.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use a2a::AgentCard;
+use a2a_pb::protojson_conv;
 use axum::{
     Json,
     extract::State,
@@ -49,8 +50,9 @@ pub fn agent_card_router<P: AgentCardProducer>(producer: Arc<P>) -> axum::Router
 async fn handle_agent_card<P: AgentCardProducer>(
     State(producer): State<Arc<P>>,
     headers: HeaderMap,
-) -> impl IntoResponse {
-    let card = producer.card();
+) -> Result<impl IntoResponse, StatusCode> {
+    let card = protojson_conv::to_value(&producer.card())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let mut resp_headers = HeaderMap::new();
 
     // CORS headers for public discovery
@@ -73,7 +75,7 @@ async fn handle_agent_card<P: AgentCardProducer>(
         resp_headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
     }
 
-    (StatusCode::OK, resp_headers, Json(card))
+    Ok((StatusCode::OK, resp_headers, Json(card)))
 }
 
 #[cfg(test)]

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -162,6 +162,26 @@ fn task_id_for_event(event: &StreamResponse) -> Option<&str> {
     }
 }
 
+fn requested_history_length(value: Option<i32>) -> Result<Option<usize>, A2AError> {
+    value
+        .map(|value| {
+            usize::try_from(value)
+                .map_err(|_| A2AError::invalid_params("historyLength must be non-negative"))
+        })
+        .transpose()
+}
+
+fn with_history_length(mut task: Task, history_length: Option<usize>) -> Task {
+    if let Some(length) = history_length {
+        if length == 0 {
+            task.history = None;
+        } else if let Some(history) = task.history.as_mut() {
+            history.drain(..history.len().saturating_sub(length));
+        }
+    }
+    task
+}
+
 fn should_interrupt_non_streaming(
     req: &SendMessageRequest,
     event: &StreamResponse,
@@ -495,6 +515,26 @@ impl DefaultRequestHandler {
     ) -> Result<(Task, Option<Task>, String), A2AError> {
         let task_id = req.message.task_id.clone().unwrap_or_else(new_task_id);
         let stored = self.task_store.get(&task_id).await?;
+        if req.message.task_id.is_some() && stored.is_none() {
+            return Err(A2AError::task_not_found(&task_id));
+        }
+        if let Some(task) = &stored {
+            if req
+                .message
+                .context_id
+                .as_ref()
+                .is_some_and(|context_id| context_id != &task.context_id)
+            {
+                return Err(A2AError::invalid_params(
+                    "context ID does not match the referenced task",
+                ));
+            }
+            if task.status.state.is_terminal() {
+                return Err(A2AError::unsupported_operation(
+                    "terminal tasks cannot accept messages",
+                ));
+            }
+        }
         let context_id = stored
             .as_ref()
             .map(|task| task.context_id.clone())
@@ -597,6 +637,11 @@ impl RequestHandler for DefaultRequestHandler {
         params: &ServiceParams,
         req: SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
+        let history_length = requested_history_length(
+            req.configuration
+                .as_ref()
+                .and_then(|config| config.history_length),
+        )?;
         let (task_id, mut stream) = self.start_execution(params, req.clone(), true).await?;
         let mut last_event = None;
 
@@ -604,9 +649,10 @@ impl RequestHandler for DefaultRequestHandler {
             let event = item?;
 
             if let Some(interrupt_task_id) = should_interrupt_non_streaming(&req, &event) {
-                return Ok(SendMessageResponse::Task(
+                return Ok(SendMessageResponse::Task(with_history_length(
                     self.load_task(&interrupt_task_id).await?,
-                ));
+                    history_length,
+                )));
             }
 
             match event {
@@ -628,6 +674,12 @@ impl RequestHandler for DefaultRequestHandler {
             Some(StreamResponse::Message(message)) => Ok(SendMessageResponse::Message(message)),
             None => Ok(SendMessageResponse::Task(self.load_task(&task_id).await?)),
         }
+        .map(|response| match response {
+            SendMessageResponse::Task(task) => {
+                SendMessageResponse::Task(with_history_length(task, history_length))
+            }
+            other => other,
+        })
     }
 
     async fn send_streaming_message(
@@ -635,8 +687,20 @@ impl RequestHandler for DefaultRequestHandler {
         params: &ServiceParams,
         req: SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        let history_length = requested_history_length(
+            req.configuration
+                .as_ref()
+                .and_then(|config| config.history_length),
+        )?;
         let (_, stream) = self.start_execution(params, req, false).await?;
-        Ok(stream)
+        Ok(Box::pin(stream.map(move |event| {
+            event.map(|event| match event {
+                StreamResponse::Task(task) => {
+                    StreamResponse::Task(with_history_length(task, history_length))
+                }
+                other => other,
+            })
+        })))
     }
 
     async fn get_task(
@@ -644,10 +708,11 @@ impl RequestHandler for DefaultRequestHandler {
         _params: &ServiceParams,
         req: GetTaskRequest,
     ) -> Result<Task, A2AError> {
-        self.task_store
-            .get(&req.id)
-            .await?
-            .ok_or_else(|| A2AError::task_not_found(&req.id))
+        let history_length = requested_history_length(req.history_length)?;
+        Ok(with_history_length(
+            self.load_task(&req.id).await?,
+            history_length,
+        ))
     }
 
     async fn list_tasks(
@@ -655,6 +720,7 @@ impl RequestHandler for DefaultRequestHandler {
         _params: &ServiceParams,
         req: ListTasksRequest,
     ) -> Result<ListTasksResponse, A2AError> {
+        let _ = requested_history_length(req.history_length)?;
         self.task_store.list(&req).await
     }
 
@@ -1124,7 +1190,6 @@ mod tests {
         let (handler, release) = make_resumable_handler();
         let params = ServiceParams::new();
         let mut message = make_message();
-        message.task_id = Some("t-disconnect".into());
         message.context_id = Some("c-disconnect".into());
 
         let mut stream = handler
@@ -1141,17 +1206,20 @@ mod tests {
             .unwrap();
 
         let initial = stream.next().await.unwrap().unwrap();
-        match initial {
-            StreamResponse::Task(task) => assert_eq!(task.status.state, TaskState::Working),
+        let task_id = match initial {
+            StreamResponse::Task(task) => {
+                assert_eq!(task.status.state, TaskState::Working);
+                task.id
+            }
             _ => panic!("expected initial working task"),
-        }
+        };
         drop(stream);
 
         let mut resumed = handler
             .subscribe_to_task(
                 &params,
                 SubscribeToTaskRequest {
-                    id: "t-disconnect".into(),
+                    id: task_id,
                     tenant: None,
                 },
             )
@@ -1353,7 +1421,6 @@ mod tests {
         let handler = make_handler();
         let params = ServiceParams::new();
         let mut msg = make_message();
-        msg.task_id = Some("t1".into());
         msg.context_id = Some("c1".into());
         let req = SendMessageRequest {
             message: msg,
@@ -1361,19 +1428,22 @@ mod tests {
             metadata: None,
             tenant: None,
         };
-        handler.send_message(&params, req).await.unwrap();
+        let task_id = match handler.send_message(&params, req).await.unwrap() {
+            SendMessageResponse::Task(task) => task.id,
+            _ => panic!("expected Task response"),
+        };
         let task = handler
             .get_task(
                 &params,
                 GetTaskRequest {
-                    id: "t1".into(),
+                    id: task_id.clone(),
                     history_length: None,
                     tenant: None,
                 },
             )
             .await
             .unwrap();
-        assert_eq!(task.id, "t1");
+        assert_eq!(task.id, task_id);
     }
 
     #[tokio::test]
@@ -1482,7 +1552,6 @@ mod tests {
         let (handler, release) = make_resumable_handler();
         let params = ServiceParams::new();
         let mut message = make_message();
-        message.task_id = Some("t-resume".into());
         message.context_id = Some("c-resume".into());
 
         let response = handler
@@ -1503,18 +1572,19 @@ mod tests {
             .await
             .unwrap();
 
-        match response {
+        let task_id = match response {
             SendMessageResponse::Task(task) => {
                 assert_eq!(task.status.state, TaskState::Working);
+                task.id
             }
             _ => panic!("expected Task response"),
-        }
+        };
 
         let mut subscription = handler
             .subscribe_to_task(
                 &params,
                 SubscribeToTaskRequest {
-                    id: "t-resume".into(),
+                    id: task_id.clone(),
                     tenant: None,
                 },
             )
@@ -1541,7 +1611,7 @@ mod tests {
             .subscribe_to_task(
                 &params,
                 SubscribeToTaskRequest {
-                    id: "t-resume".into(),
+                    id: task_id,
                     tenant: None,
                 },
             )
@@ -1688,7 +1758,6 @@ mod tests {
         let handler = make_push_delivery_handler();
         let params = ServiceParams::new();
         let mut message = make_message();
-        message.task_id = Some("t-push-request".into());
         message.context_id = Some("c-push-request".into());
 
         let response = handler
@@ -1719,16 +1788,19 @@ mod tests {
             .await
             .unwrap();
 
-        match response {
-            SendMessageResponse::Task(task) => assert_eq!(task.status.state, TaskState::Completed),
+        let task_id = match response {
+            SendMessageResponse::Task(task) => {
+                assert_eq!(task.status.state, TaskState::Completed);
+                task.id
+            }
             _ => panic!("expected Task response"),
-        }
+        };
 
         let saved = handler
             .get_push_config(
                 &params,
                 GetTaskPushNotificationConfigRequest {
-                    task_id: "t-push-request".into(),
+                    task_id: task_id.clone(),
                     id: "cfg-request".into(),
                     tenant: None,
                 },
@@ -1742,7 +1814,7 @@ mod tests {
         assert_eq!(first.notification_token.as_deref(), Some("notify-token"));
         match first.event {
             StreamResponse::StatusUpdate(update) => {
-                assert_eq!(update.task_id, "t-push-request");
+                assert_eq!(update.task_id, task_id);
                 assert_eq!(update.status.state, TaskState::Working);
             }
             _ => panic!("expected status update push"),
@@ -1753,7 +1825,7 @@ mod tests {
         assert_eq!(second.notification_token.as_deref(), Some("notify-token"));
         match second.event {
             StreamResponse::Task(task) => {
-                assert_eq!(task.id, "t-push-request");
+                assert_eq!(task.id, task_id);
                 assert_eq!(task.status.state, TaskState::Completed);
             }
             _ => panic!("expected final task push"),
@@ -1769,6 +1841,23 @@ mod tests {
         let (url, mut receiver, shutdown_tx, server) = start_push_webhook().await;
         let handler = make_push_delivery_handler();
         let params = ServiceParams::new();
+
+        handler
+            .task_store
+            .create(Task {
+                id: "t-push-stored".into(),
+                context_id: "c-push-stored".into(),
+                status: TaskStatus {
+                    state: TaskState::InputRequired,
+                    message: None,
+                    timestamp: None,
+                },
+                artifacts: None,
+                history: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
 
         handler
             .create_push_config(

--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -54,6 +54,18 @@ async fn handle_jsonrpc<H: RequestHandler>(
         return error_response(id, A2AError::invalid_request("invalid jsonrpc version"));
     }
 
+    // A missing or empty version selects legacy 0.3, which this v1 interface
+    // does not implement. Reject it before dispatching any protocol operation.
+    let mut versions = headers.get_all(SVC_PARAM_VERSION).iter();
+    let version = versions
+        .next()
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("0.3");
+    if version != VERSION || versions.next().is_some() {
+        return error_response(id, A2AError::version_not_supported(version));
+    }
+
     if methods::is_streaming(method) {
         return handle_streaming_request(&state, &params, &request).await;
     }
@@ -322,6 +334,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .body(Body::from(body))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -399,6 +412,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .body(Body::from(body))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -531,6 +545,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .header("accept", "text/event-stream")
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
             .unwrap();
@@ -551,6 +566,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -573,6 +589,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .header("accept", "text/event-stream")
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
             .unwrap();
@@ -607,6 +624,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .header("authorization", "Bearer jsonrpc-token")
             .header("x-tenant-id", "acme")
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
@@ -643,6 +661,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .header("accept", "text/event-stream")
             .header("authorization", "Bearer jsonrpc-streaming-token")
             .header("x-tenant-id", "acme")
@@ -714,6 +733,7 @@ mod tests {
                 .uri("/")
                 .method("POST")
                 .header("content-type", "application/json")
+                .header(SVC_PARAM_VERSION, VERSION)
                 .header("authorization", &token)
                 .body(Body::from(serde_json::to_string(&rpc).unwrap()))
                 .unwrap();
@@ -736,6 +756,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .header("authorization", "Bearer subscribe-token")
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
             .unwrap();
@@ -763,6 +784,7 @@ mod tests {
             .uri("/")
             .method("POST")
             .header("content-type", "application/json")
+            .header(SVC_PARAM_VERSION, VERSION)
             .body(Body::from(serde_json::to_string(&rpc).unwrap()))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/a2a-server/tests/protocol_conformance.rs
+++ b/a2a-server/tests/protocol_conformance.rs
@@ -1,0 +1,648 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+//! Released A2A v1.0.1 qualification of the pinned official Rust server.
+//! These are normative gates, not assertions that preserve known upstream bugs.
+//! Fixtures use public SDK APIs and in-process HTTP. No native host is contacted.
+
+use a2a::{
+    A2AError, AgentCapabilities, AgentCard, AgentInterface, Artifact, HttpAuthSecurityScheme,
+    Message, Part, Role, SecurityScheme, StreamResponse, Task, TaskArtifactUpdateEvent, TaskState,
+    TaskStatus, TaskStatusUpdateEvent,
+};
+use a2a_server::{
+    AgentExecutor, DefaultRequestHandler, ExecutorContext, InMemoryTaskStore, StaticAgentCard,
+    TaskStore,
+};
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use futures::{
+    StreamExt,
+    stream::{self, BoxStream},
+};
+use serde_json::{Value, json};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::sync::Notify;
+use tower::ServiceExt;
+
+const LIMIT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+struct Execution {
+    message_id: String,
+    task_id: String,
+    context_id: String,
+    transport_identity: Option<String>,
+    stored_history_ids: Vec<String>,
+}
+
+struct FixtureExecutor {
+    finish: TaskState,
+    executions: Arc<Mutex<Vec<Execution>>>,
+    release: Option<Arc<Notify>>,
+}
+
+impl AgentExecutor for FixtureExecutor {
+    fn execute(
+        &self,
+        context: ExecutorContext,
+    ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        let message = context.message.unwrap();
+        self.executions.lock().unwrap().push(Execution {
+            message_id: message.message_id.clone(),
+            task_id: context.task_id.clone(),
+            context_id: context.context_id.clone(),
+            transport_identity: context
+                .service_params
+                .get("x-fixture-identity")
+                .and_then(|values| values.first())
+                .cloned(),
+            stored_history_ids: context
+                .stored_task
+                .as_ref()
+                .and_then(|task| task.history.as_ref())
+                .into_iter()
+                .flatten()
+                .map(|message| message.message_id.clone())
+                .collect(),
+        });
+        let status = |state| TaskStatus {
+            state,
+            message: None,
+            timestamp: None,
+        };
+        let update = |state| {
+            StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                task_id: context.task_id.clone(),
+                context_id: context.context_id.clone(),
+                status: status(state),
+                metadata: None,
+            })
+        };
+        let task = Task {
+            id: context.task_id.clone(),
+            context_id: context.context_id.clone(),
+            status: status(TaskState::Submitted),
+            artifacts: None,
+            history: context
+                .stored_task
+                .and_then(|task| task.history)
+                .or_else(|| Some(vec![message])),
+            metadata: None,
+        };
+        let release = self.release.clone();
+        let events = [
+            Ok(StreamResponse::Task(task)),
+            Ok(update(TaskState::Working)),
+            Ok(StreamResponse::ArtifactUpdate(TaskArtifactUpdateEvent {
+                task_id: context.task_id.clone(),
+                context_id: context.context_id.clone(),
+                artifact: Artifact {
+                    artifact_id: "selected-reply".into(),
+                    name: None,
+                    description: None,
+                    parts: vec![Part::text("fixture reply")],
+                    metadata: None,
+                    extensions: None,
+                },
+                append: Some(false),
+                last_chunk: Some(true),
+                metadata: None,
+            })),
+            Ok(update(self.finish.clone())),
+        ];
+        Box::pin(stream::iter(events).then(move |event| {
+            let release = release.clone();
+            async move {
+                if matches!(&event, Ok(StreamResponse::StatusUpdate(update))
+                    if update.status.state == TaskState::Working)
+                {
+                    if let Some(release) = release {
+                        release.notified().await;
+                    }
+                }
+                event
+            }
+        }))
+    }
+
+    fn cancel(&self, _: ExecutorContext) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        panic!("send qualification must not cancel native work")
+    }
+}
+
+fn fixture(finish: TaskState) -> (Router, Arc<Mutex<Vec<Execution>>>) {
+    let executions = Arc::new(Mutex::new(Vec::new()));
+    let handler = DefaultRequestHandler::new(
+        FixtureExecutor {
+            finish,
+            executions: executions.clone(),
+            release: None,
+        },
+        InMemoryTaskStore::new(),
+    );
+    (
+        a2a_server::jsonrpc::jsonrpc_router(Arc::new(handler)),
+        executions,
+    )
+}
+
+fn message(id: &str) -> Value {
+    json!({
+        "message": {
+            "messageId": id,
+            "role": "ROLE_USER",
+            "parts": [{"text": "bounded fixture request"}]
+        }
+    })
+}
+
+async fn wire(
+    router: &Router,
+    method: &str,
+    params: Value,
+    version: Option<&str>,
+    identity: Option<&str>,
+) -> (bool, Vec<Value>) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("content-type", "application/json");
+    if let Some(version) = version {
+        request = request.header("A2A-Version", version);
+    }
+    if let Some(identity) = identity {
+        request = request.header("x-fixture-identity", identity);
+    }
+    let response = tokio::time::timeout(
+        LIMIT,
+        router.clone().oneshot(
+            request
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "jsonrpc": "2.0", "id": "qualification", "method": method, "params": params
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        ),
+    )
+    .await
+    .expect("protocol operation must return within the fixture deadline")
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let streaming = response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("text/event-stream");
+    let body = tokio::time::timeout(LIMIT, to_bytes(response.into_body(), 256 * 1024))
+        .await
+        .expect("completed fixture stream must close")
+        .unwrap();
+    let frames: Vec<Value> = if streaming {
+        std::str::from_utf8(&body)
+            .unwrap()
+            .lines()
+            .filter_map(|line| line.strip_prefix("data:"))
+            .map(|data| serde_json::from_str(data.trim()).unwrap())
+            .collect()
+    } else {
+        vec![serde_json::from_slice(&body).unwrap()]
+    };
+    for frame in &frames {
+        assert_eq!(frame["jsonrpc"], "2.0");
+        assert_eq!(frame["id"], "qualification");
+    }
+    (streaming, frames)
+}
+
+async fn rpc(router: &Router, method: &str, params: Value) -> Value {
+    let (streaming, mut frames) = wire(router, method, params, Some("1.0"), None).await;
+    assert!(!streaming);
+    assert_eq!(frames.len(), 1);
+    frames.remove(0)
+}
+
+#[tokio::test]
+async fn first_send_assigns_server_ids_and_retains_a_lookupable_task() {
+    let (router, executions) = fixture(TaskState::Completed);
+    let response = rpc(&router, "SendMessage", message("first")).await;
+    let task = &response["result"]["task"];
+    let task_id = task["id"].as_str().expect("server must assign task ID");
+    let context_id = task["contextId"]
+        .as_str()
+        .expect("server must assign context ID");
+    assert!(!task_id.is_empty());
+    assert!(!context_id.is_empty());
+    assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+    let fetched = rpc(&router, "GetTask", json!({"id": task_id})).await;
+    assert_eq!(&fetched["result"], task);
+    assert_eq!(executions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn supplied_unknown_task_id_cannot_create_a_task_or_dispatch_work() {
+    let (router, executions) = fixture(TaskState::Completed);
+    let mut request = message("unknown-task");
+    request["message"]["taskId"] = json!("client-cannot-create-this-id");
+    let response = rpc(&router, "SendMessage", request).await;
+    assert_eq!(
+        response["error"]["code"], -32001,
+        "v1.0.1 section 3.4.2 requires TaskNotFoundError for an unknown supplied task ID"
+    );
+    assert!(executions.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn mismatched_context_is_rejected_before_existing_task_execution() {
+    let (router, executions) = fixture(TaskState::InputRequired);
+    let first = rpc(&router, "SendMessage", message("first")).await;
+    let mut request = message("mismatched-context");
+    request["message"]["taskId"] = first["result"]["task"]["id"].clone();
+    request["message"]["contextId"] = json!("different-context");
+    let response = rpc(&router, "SendMessage", request).await;
+    assert!(
+        response.get("error").is_some(),
+        "v1.0.1 section 3.4.3 requires rejection, not silent replacement of the supplied context"
+    );
+    assert_eq!(executions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn terminal_continuation_returns_unsupported_operation_without_dispatch() {
+    let (router, executions) = fixture(TaskState::Completed);
+    let first = rpc(&router, "SendMessage", message("first")).await;
+    let mut request = message("terminal-continuation");
+    request["message"]["taskId"] = first["result"]["task"]["id"].clone();
+    let response = rpc(&router, "SendMessage", request).await;
+    assert_eq!(
+        response["error"]["code"], -32004,
+        "terminal tasks cannot accept another message under v1.0.1 section 3.1.1"
+    );
+    assert_eq!(executions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn nonterminal_continuation_infers_context_and_context_only_send_starts_a_new_task() {
+    let (router, executions) = fixture(TaskState::InputRequired);
+    let first = rpc(&router, "SendMessage", message("first")).await;
+    let first_task = &first["result"]["task"];
+    let mut continuation = message("continuation");
+    continuation["message"]["taskId"] = first_task["id"].clone();
+    let continued = rpc(&router, "SendMessage", continuation).await;
+    assert_eq!(continued["result"]["task"]["id"], first_task["id"]);
+    assert_eq!(
+        continued["result"]["task"]["contextId"],
+        first_task["contextId"]
+    );
+    let mut followup = message("context-followup");
+    followup["message"]["contextId"] = first_task["contextId"].clone();
+    let next = rpc(&router, "SendMessage", followup).await;
+    assert_ne!(next["result"]["task"]["id"], first_task["id"]);
+    assert_eq!(next["result"]["task"]["contextId"], first_task["contextId"]);
+    let executions = executions.lock().unwrap();
+    assert_eq!(executions.len(), 3);
+    assert_eq!(executions[1].message_id, "continuation");
+    assert_eq!(executions[1].task_id, executions[0].task_id);
+    assert_eq!(executions[1].context_id, executions[0].context_id);
+}
+
+async fn rejects_version(version: Option<&str>) {
+    let (router, executions) = fixture(TaskState::Completed);
+    let (_, frames) = wire(&router, "SendMessage", message("version"), version, None).await;
+    assert_eq!(
+        frames[0]["error"]["code"], -32009,
+        "a 1.0-only endpoint must reject unsupported or implicit legacy 0.3 semantics"
+    );
+    assert!(executions.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn absent_version_is_unsupported_legacy_0_3_not_implicit_1_0() {
+    rejects_version(None).await;
+}
+
+#[tokio::test]
+async fn empty_version_is_unsupported_legacy_0_3_not_implicit_1_0() {
+    rejects_version(Some("")).await;
+}
+
+#[tokio::test]
+async fn unsupported_explicit_version_is_rejected_before_execution() {
+    rejects_version(Some("0.3")).await;
+}
+
+#[tokio::test]
+async fn lifecycle_sse_preserves_initial_task_typed_updates_order_and_terminal_closure() {
+    let (router, executions) = fixture(TaskState::Completed);
+    let (streaming, frames) = wire(
+        &router,
+        "SendStreamingMessage",
+        message("stream"),
+        Some("1.0"),
+        None,
+    )
+    .await;
+    assert!(streaming);
+    assert_eq!(frames.len(), 4);
+    assert!(frames[0]["result"].get("task").is_some());
+    assert_eq!(
+        frames[1]["result"]["statusUpdate"]["status"]["state"],
+        "TASK_STATE_WORKING"
+    );
+    assert!(frames[2]["result"].get("artifactUpdate").is_some());
+    assert_eq!(
+        frames[3]["result"]["statusUpdate"]["status"]["state"],
+        "TASK_STATE_COMPLETED"
+    );
+    let task_id = &frames[0]["result"]["task"]["id"];
+    let context_id = &frames[0]["result"]["task"]["contextId"];
+    for (frame, key) in frames[1..]
+        .iter()
+        .zip(["statusUpdate", "artifactUpdate", "statusUpdate"])
+    {
+        assert_eq!(frame["result"].as_object().unwrap().len(), 1);
+        assert_eq!(&frame["result"][key]["taskId"], task_id);
+        assert_eq!(&frame["result"][key]["contextId"], context_id);
+    }
+    assert_eq!(executions.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn service_parameters_reach_each_execution_without_model_metadata_substitution() {
+    let (router, executions) = fixture(TaskState::Completed);
+    let mut a = message("a");
+    a["metadata"] = json!({"x-fixture-identity": "forged-model-a"});
+    let mut b = message("b");
+    b["metadata"] = json!({"x-fixture-identity": "forged-model-b"});
+    let (a, b) = tokio::join!(
+        wire(&router, "SendMessage", a, Some("1.0"), Some("transport-a")),
+        wire(&router, "SendMessage", b, Some("1.0"), Some("transport-b"))
+    );
+    assert!(a.1[0]["result"].get("task").is_some());
+    assert!(b.1[0]["result"].get("task").is_some());
+    let executions = executions.lock().unwrap();
+    assert_eq!(executions.len(), 2);
+    for (id, identity) in [("a", "transport-a"), ("b", "transport-b")] {
+        let execution = executions
+            .iter()
+            .find(|execution| execution.message_id == id)
+            .unwrap();
+        assert_eq!(execution.transport_identity.as_deref(), Some(identity));
+    }
+}
+
+#[tokio::test]
+async fn public_agent_card_uses_canonical_protojson_security_requirements() {
+    let card = AgentCard {
+        name: "Fixture agent".into(),
+        description: "Canonical discovery fixture".into(),
+        version: "1".into(),
+        supported_interfaces: vec![AgentInterface::new(
+            "https://example.invalid/a2a",
+            "JSONRPC",
+        )],
+        capabilities: AgentCapabilities::default(),
+        default_input_modes: vec!["text/plain".into()],
+        default_output_modes: vec!["text/plain".into()],
+        skills: vec![],
+        provider: None,
+        documentation_url: None,
+        icon_url: None,
+        security_schemes: Some(HashMap::from([(
+            "peer".into(),
+            SecurityScheme::HttpAuth(HttpAuthSecurityScheme {
+                scheme: "bearer".into(),
+                description: None,
+                bearer_format: None,
+            }),
+        )])),
+        security_requirements: Some(vec![HashMap::from([("peer".into(), vec![])])]),
+        signatures: None,
+    };
+    let router =
+        a2a_server::agent_card::agent_card_router(Arc::new(StaticAgentCard::new(card.clone())));
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(a2a_server::WELL_KNOWN_AGENT_CARD_PATH)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        value["securityRequirements"],
+        json!([{"schemes": {"peer": {}}}]),
+        "released SecurityRequirement and StringList wrappers must survive HTTP discovery"
+    );
+    let decoded: AgentCard = a2a_pb::protojson_conv::from_value(value).unwrap();
+    assert_eq!(decoded, card);
+}
+
+async fn history_fixture(release: Option<Arc<Notify>>) -> (Router, Arc<Mutex<Vec<Execution>>>) {
+    let store = InMemoryTaskStore::new();
+    let history = (0..4)
+        .map(|index| {
+            let mut message = Message::new(Role::User, vec![Part::text("fixture history")]);
+            message.message_id = format!("history-{index}");
+            message
+        })
+        .collect();
+    store
+        .create(Task {
+            id: "history-task".into(),
+            context_id: "history-context".into(),
+            status: TaskStatus {
+                state: TaskState::InputRequired,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: Some(history),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    let executions = Arc::new(Mutex::new(Vec::new()));
+    let handler = DefaultRequestHandler::new(
+        FixtureExecutor {
+            finish: TaskState::Completed,
+            executions: executions.clone(),
+            release,
+        },
+        store,
+    );
+    (
+        a2a_server::jsonrpc::jsonrpc_router(Arc::new(handler)),
+        executions,
+    )
+}
+
+fn assert_history(task: &Value, limit: usize) {
+    let actual: Vec<_> = task["history"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|message| message["messageId"].as_str().unwrap())
+        .collect();
+    let expected: Vec<_> = (4_usize.saturating_sub(limit)..4)
+        .map(|index| format!("history-{index}"))
+        .collect();
+    assert_eq!(
+        actual, expected,
+        "only the most recent requested history belongs in the response"
+    );
+    if limit == 0 {
+        assert!(task.get("history").is_none());
+    }
+}
+
+fn history_send(limit: i32) -> Value {
+    let mut request = message("history-continuation");
+    request["message"]["taskId"] = json!("history-task");
+    request["configuration"] = json!({"historyLength": limit});
+    request
+}
+
+#[tokio::test]
+async fn get_task_history_windows_do_not_modify_retained_history() {
+    let (router, executions) = history_fixture(None).await;
+    for limit in [0, 1, 3, 6] {
+        let response = rpc(
+            &router,
+            "GetTask",
+            json!({"id": "history-task", "historyLength": limit}),
+        )
+        .await;
+        assert_history(&response["result"], limit);
+        let retained = rpc(&router, "GetTask", json!({"id": "history-task"})).await;
+        assert_history(&retained["result"], 4);
+    }
+    assert!(executions.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_task_history_windows_do_not_modify_retained_history() {
+    let (router, _) = history_fixture(None).await;
+    for limit in [0, 1, 3, 6] {
+        let response = rpc(&router, "ListTasks", json!({"historyLength": limit})).await;
+        assert_history(&response["result"]["tasks"][0], limit);
+        let retained = rpc(&router, "GetTask", json!({"id": "history-task"})).await;
+        assert_history(&retained["result"], 4);
+    }
+}
+
+#[tokio::test]
+async fn send_history_windows_preserve_storage_and_executor_input() {
+    for limit in [0, 1, 3, 6] {
+        let (router, executions) = history_fixture(None).await;
+        let response = rpc(&router, "SendMessage", history_send(limit)).await;
+        assert_history(&response["result"]["task"], limit as usize);
+        let retained = rpc(&router, "GetTask", json!({"id": "history-task"})).await;
+        assert_history(&retained["result"], 4);
+        assert_eq!(
+            executions.lock().unwrap()[0].stored_history_ids,
+            ["history-0", "history-1", "history-2", "history-3"],
+            "response projection must not remove native execution context"
+        );
+    }
+}
+
+#[tokio::test]
+async fn immediate_send_applies_history_window_before_execution_completes() {
+    for limit in [0, 2] {
+        let release = Arc::new(Notify::new());
+        let (router, _) = history_fixture(Some(release.clone())).await;
+        let mut request = history_send(limit);
+        request["configuration"]["returnImmediately"] = json!(true);
+        let response = rpc(&router, "SendMessage", request).await;
+        assert_eq!(
+            response["result"]["task"]["status"]["state"],
+            "TASK_STATE_SUBMITTED"
+        );
+        assert_history(&response["result"]["task"], limit as usize);
+        let retained = rpc(&router, "GetTask", json!({"id": "history-task"})).await;
+        assert_history(&retained["result"], 4);
+        release.notify_one();
+    }
+}
+
+#[tokio::test]
+async fn streaming_initial_task_applies_history_window_without_losing_updates() {
+    for limit in [0, 2] {
+        let (router, executions) = history_fixture(None).await;
+        let (streaming, frames) = wire(
+            &router,
+            "SendStreamingMessage",
+            history_send(limit),
+            Some("1.0"),
+            None,
+        )
+        .await;
+        assert!(streaming);
+        assert_eq!(frames.len(), 4);
+        assert_history(&frames[0]["result"]["task"], limit as usize);
+        assert_eq!(
+            frames[1]["result"]["statusUpdate"]["status"]["state"],
+            "TASK_STATE_WORKING"
+        );
+        assert!(frames[2]["result"].get("artifactUpdate").is_some());
+        assert_eq!(
+            frames[3]["result"]["statusUpdate"]["status"]["state"],
+            "TASK_STATE_COMPLETED"
+        );
+        let retained = rpc(&router, "GetTask", json!({"id": "history-task"})).await;
+        assert_history(&retained["result"], 4);
+        assert_eq!(executions.lock().unwrap()[0].stored_history_ids.len(), 4);
+    }
+}
+
+#[tokio::test]
+async fn negative_history_windows_fail_before_read_operations() {
+    let (router, _) = history_fixture(None).await;
+    for (method, request) in [
+        (
+            "GetTask",
+            json!({"id": "history-task", "historyLength": -1}),
+        ),
+        ("ListTasks", json!({"historyLength": -1})),
+    ] {
+        let response = rpc(&router, method, request).await;
+        assert_eq!(response["error"]["code"], -32602);
+    }
+}
+
+#[tokio::test]
+async fn negative_send_history_windows_fail_before_executor_dispatch() {
+    for method in ["SendMessage", "SendStreamingMessage"] {
+        let (router, executions) = fixture(TaskState::Completed);
+        let mut request = message("negative-history");
+        request["configuration"] = json!({"historyLength": -1});
+        let (streaming, frames) = wire(&router, method, request, Some("1.0"), None).await;
+        assert!(
+            !streaming,
+            "invalid streaming requests must fail before SSE starts"
+        );
+        assert_eq!(frames[0]["error"]["code"], -32602);
+        assert!(executions.lock().unwrap().is_empty());
+        let tasks = rpc(&router, "ListTasks", json!({})).await;
+        assert!(
+            tasks["result"]["tasks"]
+                .as_array()
+                .is_none_or(|tasks| tasks.is_empty())
+        );
+    }
+}

--- a/examples/tests/transports_e2e.rs
+++ b/examples/tests/transports_e2e.rs
@@ -13,7 +13,7 @@ use a2a_server::jsonrpc::jsonrpc_router;
 use a2a_server::rest::rest_router;
 use a2a_server::{
     DefaultRequestHandler, ExecutorContext, HttpPushSender, InMemoryPushConfigStore,
-    InMemoryTaskStore, RequestHandler, ServiceParams, WELL_KNOWN_AGENT_CARD_PATH,
+    InMemoryTaskStore, RequestHandler, ServiceParams, TaskStore, WELL_KNOWN_AGENT_CARD_PATH,
 };
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -337,9 +337,15 @@ async fn spawn_http_server() -> (String, tokio::task::JoinHandle<()>) {
     (format!("http://{addr}"), handle)
 }
 
-async fn spawn_push_http_server() -> (String, tokio::task::JoinHandle<()>) {
+async fn spawn_push_http_server(
+    existing_task: Option<Task>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let store = InMemoryTaskStore::new();
+    if let Some(task) = existing_task {
+        store.create(task).await.unwrap();
+    }
     let handler = Arc::new(
-        DefaultRequestHandler::new(PushTransportExecutor, InMemoryTaskStore::new())
+        DefaultRequestHandler::new(PushTransportExecutor, store)
             .with_push_notifications(InMemoryPushConfigStore::new(), HttpPushSender::new(None)),
     );
     let app = Router::new()
@@ -609,14 +615,15 @@ async fn rest_transport_end_to_end() {
 async fn jsonrpc_transport_end_to_end() {
     let (base_url, handle) = spawn_http_server().await;
     let transport = JsonRpcTransport::new(Client::new(), format!("{base_url}/rpc"));
+    let params = ServiceParams::from([(SVC_PARAM_VERSION.into(), vec![VERSION.into()])]);
 
     let send_resp = transport
-        .send_message(&ServiceParams::new(), &send_message_request())
+        .send_message(&params, &send_message_request())
         .await;
     assert!(matches!(send_resp.unwrap(), SendMessageResponse::Task(_)));
 
     let stream = transport
-        .send_streaming_message(&ServiceParams::new(), &send_message_request())
+        .send_streaming_message(&params, &send_message_request())
         .await
         .unwrap();
     let items: Vec<_> = stream.collect().await;
@@ -624,7 +631,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let task = transport
         .get_task(
-            &ServiceParams::new(),
+            &params,
             &GetTaskRequest {
                 id: "task-1".to_string(),
                 history_length: Some(2),
@@ -637,7 +644,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let not_found = transport
         .get_task(
-            &ServiceParams::new(),
+            &params,
             &GetTaskRequest {
                 id: "missing".to_string(),
                 history_length: None,
@@ -650,7 +657,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let list = transport
         .list_tasks(
-            &ServiceParams::new(),
+            &params,
             &ListTasksRequest {
                 context_id: Some("ctx-1".to_string()),
                 status: Some(TaskState::Completed),
@@ -668,7 +675,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let canceled = transport
         .cancel_task(
-            &ServiceParams::new(),
+            &params,
             &CancelTaskRequest {
                 id: "task-1".to_string(),
                 metadata: None,
@@ -681,7 +688,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let cancel_missing = transport
         .cancel_task(
-            &ServiceParams::new(),
+            &params,
             &CancelTaskRequest {
                 id: "missing".to_string(),
                 metadata: None,
@@ -694,7 +701,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let subscribed = transport
         .subscribe_to_task(
-            &ServiceParams::new(),
+            &params,
             &SubscribeToTaskRequest {
                 id: "task-1".to_string(),
                 tenant: None,
@@ -706,14 +713,14 @@ async fn jsonrpc_transport_end_to_end() {
     assert_eq!(events.len(), 1);
 
     let created = transport
-        .create_push_config(&ServiceParams::new(), &sample_push_config("cfg-1"))
+        .create_push_config(&params, &sample_push_config("cfg-1"))
         .await
         .unwrap();
     assert_eq!(created.task_id, "task-1");
 
     let created_missing = transport
         .create_push_config(
-            &ServiceParams::new(),
+            &params,
             &TaskPushNotificationConfig {
                 task_id: "missing".to_string(),
                 ..sample_push_config("cfg-1")
@@ -725,7 +732,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let fetched = transport
         .get_push_config(
-            &ServiceParams::new(),
+            &params,
             &GetTaskPushNotificationConfigRequest {
                 task_id: "task-1".to_string(),
                 id: "cfg-1".to_string(),
@@ -738,7 +745,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let fetched_missing = transport
         .get_push_config(
-            &ServiceParams::new(),
+            &params,
             &GetTaskPushNotificationConfigRequest {
                 task_id: "task-1".to_string(),
                 id: "missing".to_string(),
@@ -751,7 +758,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let listed = transport
         .list_push_configs(
-            &ServiceParams::new(),
+            &params,
             &ListTaskPushNotificationConfigsRequest {
                 task_id: "task-1".to_string(),
                 page_size: Some(5),
@@ -765,7 +772,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     transport
         .delete_push_config(
-            &ServiceParams::new(),
+            &params,
             &DeleteTaskPushNotificationConfigRequest {
                 task_id: "task-1".to_string(),
                 id: "cfg-1".to_string(),
@@ -777,7 +784,7 @@ async fn jsonrpc_transport_end_to_end() {
 
     let delete_missing = transport
         .delete_push_config(
-            &ServiceParams::new(),
+            &params,
             &DeleteTaskPushNotificationConfigRequest {
                 task_id: "task-1".to_string(),
                 id: "missing".to_string(),
@@ -789,10 +796,7 @@ async fn jsonrpc_transport_end_to_end() {
     assert_eq!(delete_missing.code, error_code::TASK_NOT_FOUND);
 
     let card = transport
-        .get_extended_agent_card(
-            &ServiceParams::new(),
-            &GetExtendedAgentCardRequest { tenant: None },
-        )
+        .get_extended_agent_card(&params, &GetExtendedAgentCardRequest { tenant: None })
         .await
         .unwrap();
     assert_eq!(card.name, "Test Agent");
@@ -802,7 +806,10 @@ async fn jsonrpc_transport_end_to_end() {
 
 #[tokio::test]
 async fn rest_transport_push_delivery_end_to_end() {
-    let (base_url, server_handle) = spawn_push_http_server().await;
+    let mut existing_task = sample_task("task-rest-push", TaskState::InputRequired);
+    existing_task.context_id = "ctx-rest-push".into();
+    existing_task.status.message = None;
+    let (base_url, server_handle) = spawn_push_http_server(Some(existing_task)).await;
     let (webhook_url, mut receiver, webhook_handle) = spawn_webhook_server().await;
     let transport = RestTransport::new(Client::new(), format!("{base_url}/rest"));
 
@@ -868,12 +875,13 @@ async fn rest_transport_push_delivery_end_to_end() {
 
 #[tokio::test]
 async fn jsonrpc_transport_push_delivery_end_to_end() {
-    let (base_url, server_handle) = spawn_push_http_server().await;
+    let (base_url, server_handle) = spawn_push_http_server(None).await;
     let (webhook_url, mut receiver, webhook_handle) = spawn_webhook_server().await;
     let transport = JsonRpcTransport::new(Client::new(), format!("{base_url}/rpc"));
+    let params = ServiceParams::from([(SVC_PARAM_VERSION.into(), vec![VERSION.into()])]);
 
     let mut request = send_message_request();
-    request.message.task_id = Some("task-rpc-push".to_string());
+    request.message.task_id = None;
     request.message.context_id = Some("ctx-rpc-push".to_string());
     request.configuration = Some(SendMessageConfiguration {
         accepted_output_modes: None,
@@ -892,17 +900,17 @@ async fn jsonrpc_transport_push_delivery_end_to_end() {
         return_immediately: None,
     });
 
-    let response = transport
-        .send_message(&ServiceParams::new(), &request)
-        .await
-        .unwrap();
-    assert!(matches!(response, SendMessageResponse::Task(_)));
+    let response = transport.send_message(&params, &request).await.unwrap();
+    let task_id = match response {
+        SendMessageResponse::Task(task) => task.id,
+        _ => panic!("expected Task response"),
+    };
 
     let saved = transport
         .get_push_config(
-            &ServiceParams::new(),
+            &params,
             &GetTaskPushNotificationConfigRequest {
-                task_id: "task-rpc-push".to_string(),
+                task_id: task_id.clone(),
                 id: "cfg-rpc".to_string(),
                 tenant: None,
             },
@@ -916,7 +924,7 @@ async fn jsonrpc_transport_push_delivery_end_to_end() {
     assert_eq!(first.notification_token.as_deref(), Some("rpc-token"));
     match first.event {
         StreamResponse::StatusUpdate(update) => {
-            assert_eq!(update.task_id, "task-rpc-push");
+            assert_eq!(update.task_id, task_id);
             assert_eq!(update.status.state, TaskState::Working);
         }
         _ => panic!("expected status update push"),
@@ -927,7 +935,7 @@ async fn jsonrpc_transport_push_delivery_end_to_end() {
     assert_eq!(second.notification_token.as_deref(), Some("rpc-token"));
     match second.event {
         StreamResponse::Task(task) => {
-            assert_eq!(task.id, "task-rpc-push");
+            assert_eq!(task.id, task_id);
             assert_eq!(task.status.state, TaskState::Completed);
         }
         _ => panic!("expected final task push"),


### PR DESCRIPTION
## Summary

Fix task and discovery behavior against the released A2A v1.0.1 specification.

- Reject unknown supplied task IDs, conflicting task/context IDs, and terminal continuations before execution.
- Validate the supported A2A protocol version before JSON-RPC dispatch.
- Serialize and resolve public Agent Cards with the generated ProtoJSON codec, including empty security scope lists.
- Honor `historyLength` for GetTask, SendMessage including early returns, and streaming Task snapshots without trimming stored or executor history. Reject negative lengths before work.
- Add synthetic wire-boundary regressions and update affected transport fixtures to use valid versions and server-assigned task IDs.

## Compatibility

- Missing or empty `A2A-Version` selects legacy `0.3`, which the 1.0 interface now rejects with `VersionNotSupportedError`. Clients must send `A2A-Version: 1.0`.
- A supplied task ID must identify an existing task. New tasks use server-generated IDs.
- Agent Card security requirements use the canonical protobuf wrappers rather than the previous domain-serde shape.
- No dependency pins or public types change.

## Validation

Windows x64 with Rust 1.97.1 and default workspace features:

- 486 tests passed, including 2 doctests. No failed, ignored, or filtered tests in the final workspace run.
- Formatting, strict all-target Clippy, and workspace build passed.

```text
cargo +1.97.1 fmt --all -- --check
cargo +1.97.1 test --workspace --exclude itk-rust-current-agent --locked --offline
cargo +1.97.1 clippy --workspace --exclude itk-rust-current-agent --all-targets --locked --offline -- -D warnings
cargo +1.97.1 build --workspace --exclude itk-rust-current-agent --locked --offline
```

The `itk-rust-current-agent` exclusion follows the upstream justfile. The additional `cargo hack check/clippy --each-feature` matrix was not run because cargo-hack was not installed. These checks do not claim complete protocol qualification.

## Contributor action

Draft pending DCO sign-off by the contributor. No sign-off is included in the commit.